### PR TITLE
Allow service locator to be greater than 1.0

### DIFF
--- a/AutofacContrib.SolrNet/Properties/AssemblyInfo.cs
+++ b/AutofacContrib.SolrNet/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("AutofacContrib.SolrNet")]
 [assembly: AssemblyDescription("AutofacContrib.SolrNet")]
 [assembly: AssemblyProduct("AutofacContrib.SolrNet")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/Castle.Facilities.SolrNetIntegration/Properties/AssemblyInfo.cs
+++ b/Castle.Facilities.SolrNetIntegration/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Castle.Facilities.SolrNetIntegration")]
 [assembly: AssemblyDescription("Castle.Facilities.SolrNetIntegration")]
 [assembly: AssemblyProduct("Castle.Facilities.SolrNetIntegration")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/HttpWebAdapters/Properties/AssemblyInfo.cs
+++ b/HttpWebAdapters/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("HttpWebAdapters")]
 [assembly: AssemblyDescription("HttpWebAdapters")]
 [assembly: AssemblyProduct("HttpWebAdapters")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/NHibernate.SolrNet/Properties/AssemblyInfo.cs
+++ b/NHibernate.SolrNet/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("NHibernate.SolrNet")]
 [assembly: AssemblyDescription("NHibernate.SolrNet")]
 [assembly: AssemblyProduct("NHibernate.SolrNet")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/Ninject.Integration.SolrNet/Properties/AssemblyInfo.cs
+++ b/Ninject.Integration.SolrNet/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Ninject.Integration.SolrNet")]
 [assembly: AssemblyDescription("Ninject.Integration.SolrNet")]
 [assembly: AssemblyProduct("Ninject.Integration.SolrNet")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/SolrNet.DSL/Properties/AssemblyInfo.cs
+++ b/SolrNet.DSL/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("SolrNet.DSL")]
 [assembly: AssemblyDescription("SolrNet.DSL")]
 [assembly: AssemblyProduct("SolrNet.DSL")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/SolrNet/Impl/AbstractSolrQueryResults.cs
+++ b/SolrNet/Impl/AbstractSolrQueryResults.cs
@@ -16,6 +16,11 @@ namespace SolrNet.Impl {
         public int NumFound { get; set; }
 
         /// <summary>
+        /// Start of the results
+        /// </summary>
+        public int Start { get; set; }
+
+        /// <summary>
         /// Max score in these results
         /// </summary>
         public double? MaxScore { get; set; }

--- a/SolrNet/Impl/ResponseParsers/ResultsResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/ResultsResponseParser.cs
@@ -66,6 +66,7 @@ namespace SolrNet.Impl.ResponseParsers {
                 return;
 
             results.NumFound = Convert.ToInt32(resultNode.Attribute("numFound").Value);
+            results.Start = Convert.ToInt32(resultNode.Attribute("start").Value);
             var maxScore = resultNode.Attribute("maxScore");
             if (maxScore != null)
                 results.MaxScore = double.Parse(maxScore.Value, CultureInfo.InvariantCulture.NumberFormat);

--- a/SolrNet/Properties/AssemblyInfo.cs
+++ b/SolrNet/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("SolrNet")]
 [assembly: AssemblyDescription("SolrNet")]
 [assembly: AssemblyProduct("SolrNet")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/StructureMap.SolrNetIntegration/Properties/AssemblyInfo.cs
+++ b/StructureMap.SolrNetIntegration/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("StructureMap.SolrNetIntegration")]
 [assembly: AssemblyDescription("StructureMap.SolrNetIntegration")]
 [assembly: AssemblyProduct("StructureMap.SolrNetIntegration")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/Unity.SolrNetIntegration/Properties/AssemblyInfo.cs
+++ b/Unity.SolrNetIntegration/Properties/AssemblyInfo.cs
@@ -19,10 +19,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Unity.SolrNetIntegration")]
 [assembly: AssemblyDescription("Unity.SolrNetIntegration")]
 [assembly: AssemblyProduct("Unity.SolrNetIntegration")]
-[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2015")]
-[assembly: AssemblyVersion("0.5.0.1002")]
-[assembly: AssemblyFileVersion("0.5.0.1002")]
-[assembly: AssemblyInformationalVersion("4758ae1c6550363fb060857db120ff3aed438052")]
+[assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
+[assembly: AssemblyVersion("0.5.0.1003")]
+[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 
 

--- a/build.fsx
+++ b/build.fsx
@@ -10,8 +10,8 @@ open System.Xml.Linq
 open Fake
 open Fake.FileUtils
 
-let version = "0.5.0.1002"
-let nugetVersion = "0.5.0-alpha2"
+let version = "0.5.0.1003"
+let nugetVersion = "0.5.2"
 let buildDir = "merged"
 let nugetDir = "nuget"
 let nugetDocs = nugetDir @@ "content"
@@ -120,7 +120,7 @@ Target "NuGet" <| fun _ ->
     if File.Exists docsFile then
         cp docsFile nugetDocs
     !!(buildDir @@ "SolrNet.*") |> Copy nugetLib
-    nuGetBuild "SolrNet" "Apache Solr client" ["CommonServiceLocator", "[1.0]"]
+    nuGetBuild "SolrNet" "Apache Solr client" ["CommonServiceLocator", "1.0"]
 
 let nuGetSingle dir =
     rm_rf nugetDir


### PR DESCRIPTION
Sync from the main branch of SolrNet and update the requirement on Common Service Locator to no longer require exactly 1.0, but anything greater than or equal to 1.0
