### PR TITLE
Change document parser to support child docs

### DIFF
--- a/AutofacContrib.SolrNet/Properties/AssemblyInfo.cs
+++ b/AutofacContrib.SolrNet/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("AutofacContrib.SolrNet")]
 [assembly: AssemblyProduct("AutofacContrib.SolrNet")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/Castle.Facilities.SolrNetIntegration/Properties/AssemblyInfo.cs
+++ b/Castle.Facilities.SolrNetIntegration/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Castle.Facilities.SolrNetIntegration")]
 [assembly: AssemblyProduct("Castle.Facilities.SolrNetIntegration")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/HttpWebAdapters/Properties/AssemblyInfo.cs
+++ b/HttpWebAdapters/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("HttpWebAdapters")]
 [assembly: AssemblyProduct("HttpWebAdapters")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/NHibernate.SolrNet/Properties/AssemblyInfo.cs
+++ b/NHibernate.SolrNet/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("NHibernate.SolrNet")]
 [assembly: AssemblyProduct("NHibernate.SolrNet")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/Ninject.Integration.SolrNet/Properties/AssemblyInfo.cs
+++ b/Ninject.Integration.SolrNet/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Ninject.Integration.SolrNet")]
 [assembly: AssemblyProduct("Ninject.Integration.SolrNet")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/SolrNet.DSL/Properties/AssemblyInfo.cs
+++ b/SolrNet.DSL/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("SolrNet.DSL")]
 [assembly: AssemblyProduct("SolrNet.DSL")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/SolrNet.Tests/GenericDictionaryDocumentVisitorTests.cs
+++ b/SolrNet.Tests/GenericDictionaryDocumentVisitorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using MbUnit.Framework;
 using SolrNet.Attributes;
 using SolrNet.Impl;
@@ -8,32 +9,37 @@ using SolrNet.Impl.FieldParsers;
 using SolrNet.Mapping;
 using SolrNet.Tests.Utils;
 
-namespace SolrNet.Tests {
-    [TestFixture]
-    public class GenericDictionaryDocumentVisitorTests {
+namespace SolrNet.Tests
+{
+	[TestFixture]
+	public class GenericDictionaryDocumentVisitorTests
+	{
 
-        [Test]
-        public void ParseDictionaryOfCollection() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.docWithDynamicFields.xml");
-            var mapper = new AttributesMappingManager();
-            var parser = new SolrDocumentResponseParser<Entity>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Entity>());
-            var entity = parser.ParseDocument(xml.Root);
-            Assert.IsNotNull(entity, "entity was null");
-            Assert.IsNotNull(entity.Attributes, "attributes was null");
-            Assert.AreEqual(16, entity.Attributes.Count);
+		[Test]
+		public void ParseDictionaryOfCollection()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.docWithDynamicFields.xml");
+			var mapper = new AttributesMappingManager();
+			var parser = new SolrDocumentResponseParser<Entity>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Entity>());
+			var entities = parser.ParseDocument(xml.Root).ToList();
+			var entity = entities[0];
+			Assert.IsNotNull(entity, "entity was null");
+			Assert.IsNotNull(entity.Attributes, "attributes was null");
+			Assert.AreEqual(16, entity.Attributes.Count);
 
-            var attr2 = entity.Attributes["2"];
-            Assert.AreEqual(5, attr2.Count);
-            Assert.Contains(attr2, 63);
-            Assert.Contains(attr2, 64);
-            Assert.Contains(attr2, 65);
-            Assert.Contains(attr2, 66);
-            Assert.Contains(attr2, 102);
-        }
+			var attr2 = entity.Attributes["2"];
+			Assert.AreEqual(5, attr2.Count);
+			Assert.Contains(attr2, 63);
+			Assert.Contains(attr2, 64);
+			Assert.Contains(attr2, 65);
+			Assert.Contains(attr2, 66);
+			Assert.Contains(attr2, 102);
+		}
 
-        class Entity {
-            [SolrField("attr_")]
-            public IDictionary<string, ICollection<int>> Attributes { get; set; }
-        }
-    }
+		class Entity
+		{
+			[SolrField("attr_")]
+			public IDictionary<string, ICollection<int>> Attributes { get; set; }
+		}
+	}
 }

--- a/SolrNet.Tests/GenericDictionaryDocumentVisitorTests.cs
+++ b/SolrNet.Tests/GenericDictionaryDocumentVisitorTests.cs
@@ -43,4 +43,3 @@ namespace SolrNet.Tests
 		}
 	}
 }
-

--- a/SolrNet.Tests/GenericDictionaryDocumentVisitorTests.cs
+++ b/SolrNet.Tests/GenericDictionaryDocumentVisitorTests.cs
@@ -43,3 +43,4 @@ namespace SolrNet.Tests
 		}
 	}
 }
+

--- a/SolrNet.Tests/Resources/responseWithMultipleChildren.xml
+++ b/SolrNet.Tests/Resources/responseWithMultipleChildren.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <lst name="responseHeader">
+    <int name="status">1</int>
+    <int name="QTime">15</int>
+    <lst name="params">
+      <str name="q">id:123456</str>
+      <str name="version">2.2</str>
+    </lst>
+  </lst>
+  <result name="response" numFound="2" start="0">
+    <doc>
+      <str name="advancedview"/>
+      <str name="basicview"/>
+      <int name="id">123456</int>
+      <str name="location">51.5171,-0.1062</str>
+      <str name="sameFieldName">parent value</str>
+      <doc>
+        <str name="childField">abcdef</str>
+        <str name="sameFieldName">child value</str>
+      </doc>
+      <doc>
+        <str name="childField">wxyz</str>
+        <str name="sameFieldName">child value</str>
+      </doc>
+    </doc>
+    <doc>
+      <str name="advancedview"/>
+      <str name="basicview"/>
+      <int name="id">789</int>
+      <str name="location">51.5171,-0.1062</str>
+      <str name="sameFieldName">parent value</str>
+    </doc>
+  </result>
+  <str name="nextCursorMark">AoEoZTQ3YmY0NDM=</str>
+</response>

--- a/SolrNet.Tests/SolrNet.Tests.csproj
+++ b/SolrNet.Tests/SolrNet.Tests.csproj
@@ -346,6 +346,11 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\responseWithSpellChecking2.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\responseWithMultipleChildren.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -31,127 +31,115 @@ using SolrNet.Mapping;
 using SolrNet.Tests.Utils;
 using Castle.Facilities.SolrNetIntegration;
 
-namespace SolrNet.Tests
-{
+namespace SolrNet.Tests {
 	[TestFixture]
-	public partial class SolrQueryResultsParserTests
-	{
+	public partial class SolrQueryResultsParserTests {
 
-		private static SolrDocumentResponseParser<T> GetDocumentParser<T>()
-		{
-			var mapper = new AttributesMappingManager();
-			return GetDocumentParser<T>(mapper);
-		}
+        private static SolrDocumentResponseParser<T> GetDocumentParser<T>() {
+            var mapper = new AttributesMappingManager();
+            return GetDocumentParser<T>(mapper);
+        }
 
-		private static SolrDocumentResponseParser<T> GetDocumentParser<T>(IReadOnlyMappingManager mapper)
-		{
-			return new SolrDocumentResponseParser<T>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<T>());
-		}
+        private static SolrDocumentResponseParser<T> GetDocumentParser<T>(IReadOnlyMappingManager mapper) {
+            return new SolrDocumentResponseParser<T>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<T>());
+        }
+		
+				[Test]
+				public void ParseDocument() {
+					var parser = GetDocumentParser<TestDocument>();
+					var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+					var docNode = xml.XPathSelectElement("response/result/doc");
+					var docs = parser.ParseDocument(docNode).ToList();
+					Assert.IsTrue(docs.Count > 0);
+					Assert.AreEqual(123456, docs[0].Id);
+				}
 
-		[Test]
-		public void ParseDocument()
-		{
-			var parser = GetDocumentParser<TestDocument>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-			var docNode = xml.XPathSelectElement("response/result/doc");
-			var docs = parser.ParseDocument(docNode).ToList();
-			Assert.IsTrue(docs.Count > 0);
-			Assert.AreEqual(123456, docs[0].Id);
-		}
+				[Test]
+				public void ParseDocumentWithChildren() {
+					var parser = GetDocumentParser<TestDocumentWithChildren>();
+					var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMultipleChildren.xml");
+					var docNode = xml.XPathSelectElement("response/result/doc");
+					var docs = parser.ParseDocument(docNode).ToList();
+					Assert.AreEqual(2, docs.Count);
+					Assert.AreEqual(123456, docs[0].Id);
+					Assert.AreEqual(123456, docs[1].Id);
 
-		[Test]
-		public void ParseDocumentWithChildren()
-		{
-			var parser = GetDocumentParser<TestDocumentWithChildren>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMultipleChildren.xml");
-			var docNode = xml.XPathSelectElement("response/result/doc");
-			var docs = parser.ParseDocument(docNode).ToList();
-			Assert.AreEqual(2, docs.Count);
-			Assert.AreEqual(123456, docs[0].Id);
-			Assert.AreEqual(123456, docs[1].Id);
+					Assert.AreEqual("abcdef", docs[0].ChildField);
+					Assert.AreEqual("wxyz", docs[1].ChildField);
 
-			Assert.AreEqual("abcdef", docs[0].ChildField);
-			Assert.AreEqual("wxyz", docs[1].ChildField);
+					Assert.AreEqual("child value", docs[0].SameFieldName);
+					Assert.AreEqual("child value", docs[1].SameFieldName);
+				}
 
-			Assert.AreEqual("child value", docs[0].SameFieldName);
-			Assert.AreEqual("child value", docs[1].SameFieldName);
-		}
+				[Test]
+				public void ParseResultsWithChildren() {
+					var parser = GetDocumentParser<TestDocumentWithChildren>();
+					var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMultipleChildren.xml");
+					var resultNode = xml.XPathSelectElement("response/result");
+					var docs = parser.ParseResults(resultNode).ToList();
+					Assert.AreEqual(3, docs.Count);
+					Assert.AreEqual(123456, docs[0].Id);
+					Assert.AreEqual(123456, docs[1].Id);
+					Assert.AreEqual(789, docs[2].Id);
 
-		[Test]
-		public void ParseResultsWithChildren()
-		{
-			var parser = GetDocumentParser<TestDocumentWithChildren>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMultipleChildren.xml");
-			var resultNode = xml.XPathSelectElement("response/result");
-			var docs = parser.ParseResults(resultNode).ToList();
-			Assert.AreEqual(3, docs.Count);
-			Assert.AreEqual(123456, docs[0].Id);
-			Assert.AreEqual(123456, docs[1].Id);
-			Assert.AreEqual(789, docs[2].Id);
+					Assert.AreEqual("abcdef", docs[0].ChildField);
+					Assert.AreEqual("wxyz", docs[1].ChildField);
+					Assert.IsNull(docs[2].ChildField);
 
-			Assert.AreEqual("abcdef", docs[0].ChildField);
-			Assert.AreEqual("wxyz", docs[1].ChildField);
-			Assert.IsNull(docs[2].ChildField);
-
-			Assert.AreEqual("child value", docs[0].SameFieldName);
-			Assert.AreEqual("child value", docs[1].SameFieldName);
-			Assert.AreEqual("parent value", docs[2].SameFieldName);
-		}
+					Assert.AreEqual("child value", docs[0].SameFieldName);
+					Assert.AreEqual("child value", docs[1].SameFieldName);
+					Assert.AreEqual("parent value", docs[2].SameFieldName);
+				}
 
 		[Test]
-		public void ParseDocumentWithMappingManager()
-		{
-			var mapper = new MappingManager();
-			mapper.Add(typeof(TestDocumentWithoutAttributes).GetProperty("Id"), "id");
-			var parser = GetDocumentParser<TestDocumentWithoutAttributes>(mapper);
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-			var docNode = xml.XPathSelectElement("response/result/doc");
-			var docs = parser.ParseDocument(docNode).ToList();
-			Assert.IsTrue(docs.Count > 0);
-			Assert.AreEqual(123456, docs[0].Id);
-		}
+	    public void ParseDocumentWithMappingManager() {
+            var mapper = new MappingManager();
+            mapper.Add(typeof(TestDocumentWithoutAttributes).GetProperty("Id"), "id");
+            var parser = GetDocumentParser<TestDocumentWithoutAttributes>(mapper);
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+            var docNode = xml.XPathSelectElement("response/result/doc");
+            var doc = parser.ParseDocument(docNode).ToList();
+			Assert.IsNotNull(doc);
+			Assert.AreEqual(123456, doc[0].Id);
+	    }
 
-		private static SolrQueryResults<T> ParseFromResource<T>(string xmlResource)
-		{
-			var docParser = GetDocumentParser<T>();
-			var parser = new ResultsResponseParser<T>(docParser);
-			var r = new SolrQueryResults<T>();
-			var xml = EmbeddedResource.GetEmbeddedXml(typeof(SolrQueryResultsParserTests), xmlResource);
-			parser.Parse(xml, r);
-			return r;
-		}
+        private static SolrQueryResults<T> ParseFromResource<T>(string xmlResource) {
+            var docParser = GetDocumentParser<T>();
+            var parser = new ResultsResponseParser<T>(docParser);
+            var r = new SolrQueryResults<T>();
+            var xml = EmbeddedResource.GetEmbeddedXml(typeof(SolrQueryResultsParserTests), xmlResource);
+            parser.Parse(xml, r);
+            return r;
+        }
 
 		[Test]
-		public void NumFound()
-		{
-			var r = ParseFromResource<TestDocument>("Resources.response.xml");
+		public void NumFound() {
+		    var r = ParseFromResource<TestDocument>("Resources.response.xml");
 			Assert.AreEqual(1, r.NumFound);
 		}
 
-		[Test]
-		public void CanParseNextCursormark()
-		{
-			var r = ParseFromResource<TestDocument>("Resources.response.xml");
-			Assert.AreEqual(new StartOrCursor.Cursor("AoEoZTQ3YmY0NDM="), r.NextCursorMark);
-		}
+        [Test]
+        public void CanParseNextCursormark()
+        {
+            var r = ParseFromResource<TestDocument>("Resources.response.xml");
+            Assert.AreEqual(new StartOrCursor.Cursor("AoEoZTQ3YmY0NDM="), r.NextCursorMark);
+        }
 
 		[Test]
-		public void Parse()
-		{
-			var results = ParseFromResource<TestDocument>("Resources.response.xml");
-			Assert.AreEqual(1, results.Count);
+		public void Parse() {
+		    var results = ParseFromResource<TestDocument>("Resources.response.xml");
+    		Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(123456, doc.Id);
 		}
 
 		[Test]
-		public void SetPropertyWithArrayOfStrings()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='cat']");
-			var mapper = new AttributesMappingManager();
-			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-			var doc = new TestDocumentWithArrays();
+		public void SetPropertyWithArrayOfStrings() {
+		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='cat']");
+            var mapper = new AttributesMappingManager();
+		    var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+            var doc = new TestDocumentWithArrays();
 			visitor.Visit(doc, "cat", fieldNode);
 			Assert.AreEqual(2, doc.Cat.Count);
 			var cats = new List<string>(doc.Cat);
@@ -160,38 +148,35 @@ namespace SolrNet.Tests
 		}
 
 		[Test]
-		public void SetPropertyDouble()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-			var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
-			var mapper = new AttributesMappingManager();
-			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-			var doc = new TestDocumentWithArrays();
-			visitor.Visit(doc, "price", fieldNode);
+		public void SetPropertyDouble() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+            var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
+            var mapper = new AttributesMappingManager();
+            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+            var doc = new TestDocumentWithArrays();
+            visitor.Visit(doc, "price", fieldNode);
 			Assert.AreEqual(92d, doc.Price);
 		}
 
 		[Test]
-		public void SetPropertyNullableDouble()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-			var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
-			var mapper = new AttributesMappingManager();
-			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-			var doc = new TestDocumentWithNullableDouble();
-			visitor.Visit(doc, "price", fieldNode);
+		public void SetPropertyNullableDouble() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+            var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
+            var mapper = new AttributesMappingManager();
+            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+            var doc = new TestDocumentWithNullableDouble();
+            visitor.Visit(doc, "price", fieldNode);
 			Assert.AreEqual(92d, doc.Price);
 		}
 
 		[Test]
-		public void SetPropertyWithIntCollection()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
-			var mapper = new AttributesMappingManager();
-			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-			var doc = new TestDocumentWithArrays();
-			visitor.Visit(doc, "numbers", fieldNode);
+		public void SetPropertyWithIntCollection() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
+            var mapper = new AttributesMappingManager();
+            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+            var doc = new TestDocumentWithArrays();
+            visitor.Visit(doc, "numbers", fieldNode);
 			Assert.AreEqual(2, doc.Numbers.Count);
 			var numbers = new List<int>(doc.Numbers);
 			Assert.AreEqual(1, numbers[0]);
@@ -199,14 +184,13 @@ namespace SolrNet.Tests
 		}
 
 		[Test]
-		public void SetPropertyWithNonGenericCollection()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
-			var mapper = new AttributesMappingManager();
-			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-			var doc = new TestDocumentWithArrays3();
-			visitor.Visit(doc, "numbers", fieldNode);
+		public void SetPropertyWithNonGenericCollection() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
+            var mapper = new AttributesMappingManager();
+            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+            var doc = new TestDocumentWithArrays3();
+            visitor.Visit(doc, "numbers", fieldNode);
 			Assert.AreEqual(2, doc.Numbers.Count);
 			var numbers = new ArrayList(doc.Numbers);
 			Assert.AreEqual(1, numbers[0]);
@@ -214,14 +198,13 @@ namespace SolrNet.Tests
 		}
 
 		[Test]
-		public void SetPropertyWithArrayOfIntsToIntArray()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
-			var mapper = new AttributesMappingManager();
-			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-			var doc = new TestDocumentWithArrays2();
-			visitor.Visit(doc, "numbers", fieldNode);
+		public void SetPropertyWithArrayOfIntsToIntArray() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
+            var mapper = new AttributesMappingManager();
+            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+            var doc = new TestDocumentWithArrays2();
+            visitor.Visit(doc, "numbers", fieldNode);
 			Assert.AreEqual(2, doc.Numbers.Length);
 			var numbers = new List<int>(doc.Numbers);
 			Assert.AreEqual(1, numbers[0]);
@@ -229,240 +212,216 @@ namespace SolrNet.Tests
 		}
 
 		[Test]
-		public void ParseResultsWithArrays()
-		{
-			var results = ParseFromResource<TestDocumentWithArrays>("Resources.responseWithArrays.xml");
+		public void ParseResultsWithArrays() {
+		    var results = ParseFromResource<TestDocumentWithArrays>("Resources.responseWithArrays.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual("SP2514N", doc.Id);
 		}
 
 		[Test]
-		public void SupportsDateTime()
-		{
-			var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithDate.xml");
+		public void SupportsDateTime() {
+		    var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithDate.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5), doc.Fecha);
 		}
 
 		[Test]
-		public void ParseDate_without_milliseconds()
-		{
-			var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05Z");
+		public void ParseDate_without_milliseconds() {
+            var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05Z");
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5), dt);
 		}
 
 		[Test]
-		public void ParseDate_with_milliseconds()
-		{
-			var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05.245Z");
+		public void ParseDate_with_milliseconds() {
+            var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05.245Z");
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5, 245), dt);
 		}
 
 		[Test]
-		public void SupportsNullableDateTime()
-		{
-			var results = ParseFromResource<TestDocumentWithNullableDate>("Resources.responseWithDate.xml");
+		public void SupportsNullableDateTime() {
+		    var results = ParseFromResource<TestDocumentWithNullableDate>("Resources.responseWithDate.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5), doc.Fecha);
 		}
 
 		[Test]
-		public void SupportsIEnumerable()
-		{
-			var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
+		public void SupportsIEnumerable() {
+            var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(2, new List<string>(doc.Features).Count);
 		}
 
-		[Test]
-		public void SupportsGuid()
-		{
-			var results = ParseFromResource<TestDocWithGuid>("Resources.responseWithGuid.xml");
-			Assert.AreEqual(1, results.Count);
-			var doc = results[0];
-			//Console.WriteLine(doc.Key);
-		}
+        [Test]
+        public void SupportsGuid() {
+            var results = ParseFromResource<TestDocWithGuid>("Resources.responseWithGuid.xml");
+            Assert.AreEqual(1, results.Count);
+            var doc = results[0];
+            //Console.WriteLine(doc.Key);
+        }
+
+        [Test]
+        public void SupportsEnumAsInteger() {
+            var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsInt.xml");
+            Assert.AreEqual(1, results.Count);
+            var doc = results[0];
+            //Console.WriteLine(doc.En);
+        }
+
+        [Test]
+        public void SupportsEnumAsString() {
+            var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsString.xml");
+            Assert.AreEqual(1, results.Count);
+            var doc = results[0];
+            //Console.WriteLine(doc.En);
+        }
+
+        [Test]
+        [ExpectedException(typeof(Exception))]
+        public void EmptyEnumThrows() {
+            var mapper = new MappingManager();
+            mapper.Add(typeof(TestDocWithEnum).GetProperty("En"), "basicview");
+            var docParser = GetDocumentParser<TestDocWithEnum>(mapper);
+            var parser = new ResultsResponseParser<TestDocWithEnum>(docParser);
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+            var results = new SolrQueryResults<TestDocWithEnum>();
+            parser.Parse(xml, results);
+        }
+
+        [Test]
+        public void SupportsNullableGuidWithEmptyField() {
+            var results = ParseFromResource<TestDocWithNullableEnum>("Resources.response.xml");
+            Assert.AreEqual(1, results.Count);
+            Assert.IsFalse(results[0].BasicView.HasValue);
+        }
+
+        [Test]
+        public void GenericDictionary_string_string() {
+            var results = ParseFromResource<TestDocWithGenDict>("Resources.responseWithDict.xml");
+            Assert.AreEqual(1, results.Count);
+            var doc = results[0];
+            Assert.IsNotNull(doc.Dict);
+            Assert.AreEqual(2, doc.Dict.Count);
+            Assert.AreEqual("1", doc.Dict["One"]);
+            Assert.AreEqual("2", doc.Dict["Two"]);
+        }
+
+        [Test]
+        public void GenericDictionary_string_int() {
+            var results = ParseFromResource<TestDocWithGenDict2>("Resources.responseWithDict.xml");
+            Assert.AreEqual(1, results.Count);
+            var doc = results[0];
+            Assert.IsNotNull(doc.Dict);
+            Assert.AreEqual(2, doc.Dict.Count);
+            Assert.AreEqual(1, doc.Dict["One"]);
+            Assert.AreEqual(2, doc.Dict["Two"]);
+        }
+
+        [Test]
+        public void GenericDictionary_string_float() {
+            var results = ParseFromResource<TestDocWithGenDict3>("Resources.responseWithDictFloat.xml");
+            Assert.AreEqual(1, results.Count);
+            var doc = results[0];
+            Assert.IsNotNull(doc.Dict);
+            Assert.AreEqual(2, doc.Dict.Count);
+            Assert.AreEqual(1.45f, doc.Dict["One"]);
+            Assert.AreEqual(2.234f, doc.Dict["Two"]);
+        }
+
+        [Test]
+        public void GenericDictionary_string_decimal() {
+            var results = ParseFromResource<TestDocWithGenDict4>("Resources.responseWithDictFloat.xml");
+            Assert.AreEqual(1, results.Count);
+            var doc = results[0];
+            Assert.IsNotNull(doc.Dict);
+            Assert.AreEqual(2, doc.Dict.Count);
+            Assert.AreEqual(1.45m, doc.Dict["One"]);
+            Assert.AreEqual(2.234m, doc.Dict["Two"]);
+        }
+
+        [Test]
+        public void GenericDictionary_rest_of_fields() {
+            var results = ParseFromResource<TestDocWithGenDict5>("Resources.responseWithDictFloat.xml");
+            Assert.AreEqual("1.45", results[0].DictOne);
+            Assert.IsNotNull(results[0].Dict);
+            Assert.AreEqual(4, results[0].Dict.Count);
+            Assert.AreEqual("2.234", results[0].Dict["DictTwo"]);
+            Assert.AreEqual(new DateTime(1, 1, 1), results[0].Dict["timestamp"]);
+            Assert.AreEqual(92.0f, results[0].Dict["price"]);
+            Assert.IsInstanceOfType(typeof(ICollection), results[0].Dict["features"]);
+        }
 
 		[Test]
-		public void SupportsEnumAsInteger()
-		{
-			var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsInt.xml");
-			Assert.AreEqual(1, results.Count);
-			var doc = results[0];
-			//Console.WriteLine(doc.En);
-		}
-
-		[Test]
-		public void SupportsEnumAsString()
-		{
-			var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsString.xml");
-			Assert.AreEqual(1, results.Count);
-			var doc = results[0];
-			//Console.WriteLine(doc.En);
-		}
-
-		[Test]
-		[ExpectedException(typeof(Exception))]
-		public void EmptyEnumThrows()
-		{
-			var mapper = new MappingManager();
-			mapper.Add(typeof(TestDocWithEnum).GetProperty("En"), "basicview");
-			var docParser = GetDocumentParser<TestDocWithEnum>(mapper);
-			var parser = new ResultsResponseParser<TestDocWithEnum>(docParser);
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-			var results = new SolrQueryResults<TestDocWithEnum>();
-			parser.Parse(xml, results);
-		}
-
-		[Test]
-		public void SupportsNullableGuidWithEmptyField()
-		{
-			var results = ParseFromResource<TestDocWithNullableEnum>("Resources.response.xml");
-			Assert.AreEqual(1, results.Count);
-			Assert.IsFalse(results[0].BasicView.HasValue);
-		}
-
-		[Test]
-		public void GenericDictionary_string_string()
-		{
-			var results = ParseFromResource<TestDocWithGenDict>("Resources.responseWithDict.xml");
-			Assert.AreEqual(1, results.Count);
-			var doc = results[0];
-			Assert.IsNotNull(doc.Dict);
-			Assert.AreEqual(2, doc.Dict.Count);
-			Assert.AreEqual("1", doc.Dict["One"]);
-			Assert.AreEqual("2", doc.Dict["Two"]);
-		}
-
-		[Test]
-		public void GenericDictionary_string_int()
-		{
-			var results = ParseFromResource<TestDocWithGenDict2>("Resources.responseWithDict.xml");
-			Assert.AreEqual(1, results.Count);
-			var doc = results[0];
-			Assert.IsNotNull(doc.Dict);
-			Assert.AreEqual(2, doc.Dict.Count);
-			Assert.AreEqual(1, doc.Dict["One"]);
-			Assert.AreEqual(2, doc.Dict["Two"]);
-		}
-
-		[Test]
-		public void GenericDictionary_string_float()
-		{
-			var results = ParseFromResource<TestDocWithGenDict3>("Resources.responseWithDictFloat.xml");
-			Assert.AreEqual(1, results.Count);
-			var doc = results[0];
-			Assert.IsNotNull(doc.Dict);
-			Assert.AreEqual(2, doc.Dict.Count);
-			Assert.AreEqual(1.45f, doc.Dict["One"]);
-			Assert.AreEqual(2.234f, doc.Dict["Two"]);
-		}
-
-		[Test]
-		public void GenericDictionary_string_decimal()
-		{
-			var results = ParseFromResource<TestDocWithGenDict4>("Resources.responseWithDictFloat.xml");
-			Assert.AreEqual(1, results.Count);
-			var doc = results[0];
-			Assert.IsNotNull(doc.Dict);
-			Assert.AreEqual(2, doc.Dict.Count);
-			Assert.AreEqual(1.45m, doc.Dict["One"]);
-			Assert.AreEqual(2.234m, doc.Dict["Two"]);
-		}
-
-		[Test]
-		public void GenericDictionary_rest_of_fields()
-		{
-			var results = ParseFromResource<TestDocWithGenDict5>("Resources.responseWithDictFloat.xml");
-			Assert.AreEqual("1.45", results[0].DictOne);
-			Assert.IsNotNull(results[0].Dict);
-			Assert.AreEqual(4, results[0].Dict.Count);
-			Assert.AreEqual("2.234", results[0].Dict["DictTwo"]);
-			Assert.AreEqual(new DateTime(1, 1, 1), results[0].Dict["timestamp"]);
-			Assert.AreEqual(92.0f, results[0].Dict["price"]);
-			Assert.IsInstanceOfType(typeof(ICollection), results[0].Dict["features"]);
-		}
-
-		[Test]
-		public void WrongFieldDoesntThrow()
-		{
-			var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithArraysSimple.xml");
+		public void WrongFieldDoesntThrow() {
+            var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithArraysSimple.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 		}
 
 		[Test]
-		public void ReadsMaxScoreAttribute()
-		{
-			var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
+		public void ReadsMaxScoreAttribute() {
+            var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
 			Assert.AreEqual(1.6578954, results.MaxScore);
 		}
 
 		[Test]
-		public void ReadMaxScore_doesnt_crash_if_not_present()
-		{
-			var results = ParseFromResource<TestDocument>("Resources.response.xml");
+		public void ReadMaxScore_doesnt_crash_if_not_present() {
+            var results = ParseFromResource<TestDocument>("Resources.response.xml");
 			Assert.IsNull(results.MaxScore);
 		}
 
-		public void ProfileTest(ProfilingContainer container)
-		{
-			var parser = container.Resolve<ISolrAbstractResponseParser<TestDocumentWithArrays>>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArraysSimple.xml");
-			var results = new SolrQueryResults<TestDocumentWithArrays>();
+        public void ProfileTest(ProfilingContainer container) {
+            var parser = container.Resolve<ISolrAbstractResponseParser<TestDocumentWithArrays>>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArraysSimple.xml");
+            var results = new SolrQueryResults<TestDocumentWithArrays>();
 
-			for (var i = 0; i < 1000; i++)
-			{
-				parser.Parse(xml, results);
-			}
+            for (var i = 0; i < 1000; i++) {
+                parser.Parse(xml, results);
+            }
 
-			var profile = Flatten(container.GetProfile());
-			var q = from n in profile
-							group n.Value by n.Key into x
-							let kv = new { method = x.Key, count = x.Count(), total = x.Sum(t => t.TotalMilliseconds) }
-							orderby kv.total descending
-							select kv;
+            var profile = Flatten(container.GetProfile());
+            var q = from n in profile
+                    group n.Value by n.Key into x
+                    let kv = new { method = x.Key, count = x.Count(), total = x.Sum(t => t.TotalMilliseconds)}
+                    orderby kv.total descending
+                    select kv;
 
-			//foreach (var i in q)
-			//    Console.WriteLine("{0} {1}: {2} executions, {3}ms", i.method.DeclaringType, i.method, i.count, i.total);
+            //foreach (var i in q)
+            //    Console.WriteLine("{0} {1}: {2} executions, {3}ms", i.method.DeclaringType, i.method, i.count, i.total);
 
-		}
+        }
 
-		public IEnumerable<KeyValuePair<MethodInfo, TimeSpan>> Flatten(Node<KeyValuePair<MethodInfo, TimeSpan>> n)
-		{
-			if (n.Value.Key != null)
-				yield return n.Value;
-			foreach (var i in n.Children.SelectMany(Flatten))
-				yield return i;
-		}
+        public IEnumerable<KeyValuePair<MethodInfo, TimeSpan>> Flatten(Node<KeyValuePair<MethodInfo, TimeSpan>> n) {
+            if (n.Value.Key != null)
+                yield return n.Value;
+            foreach (var i in n.Children.SelectMany(Flatten))
+                yield return i;
+        }
 
 
 		[Test]
 		[Ignore("Performance test, potentially slow")]
-		public void Performance()
-		{
-			var container = new ProfilingContainer();
-			container.AddFacility("solr", new SolrNetFacility("http://localhost"));
-			ProfileTest(container);
+		public void Performance() {
+		    var container = new ProfilingContainer();
+            container.AddFacility("solr", new SolrNetFacility("http://localhost"));
+            ProfileTest(container);
 		}
 
 		[Test]
-		public void ParseFacetResults()
-		{
-			var parser = new FacetsResponseParser<TestDocumentWithArrays>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacet.xml");
-			var r = new SolrQueryResults<TestDocumentWithArrays>();
-			parser.Parse(xml, r);
+		public void ParseFacetResults() {
+		    var parser = new FacetsResponseParser<TestDocumentWithArrays>();
+		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacet.xml");
+		    var r = new SolrQueryResults<TestDocumentWithArrays>();
+		    parser.Parse(xml, r);
 			Assert.IsNotNull(r.FacetFields);
 			//Console.WriteLine(r.FacetFields.Count);
 			Assert.IsTrue(r.FacetFields.ContainsKey("cat"));
 			Assert.IsTrue(r.FacetFields.ContainsKey("inStock"));
 			Assert.AreEqual(2, r.FacetFields["cat"].First(q => q.Key == "connector").Value);
-			Assert.AreEqual(2, r.FacetFields["cat"].First(q => q.Key == "").Value); // facet.missing as empty string
+            Assert.AreEqual(2, r.FacetFields["cat"].First(q => q.Key == "").Value); // facet.missing as empty string
 
 			Assert.IsNotNull(r.FacetQueries);
 			//Console.WriteLine(r.FacetQueries.Count);
@@ -470,11 +429,10 @@ namespace SolrNet.Tests
 		}
 
 		[Test]
-		public void ParseResponseHeader()
-		{
-			var parser = new HeaderResponseParser<TestDocument>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-			var docNode = xml.XPathSelectElement("response/lst[@name='responseHeader']");
+		public void ParseResponseHeader() {
+		    var parser = new HeaderResponseParser<TestDocument>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='responseHeader']");
 			var header = parser.ParseHeader(docNode);
 			Assert.AreEqual(1, header.Status);
 			Assert.AreEqual(15, header.QTime);
@@ -483,141 +441,133 @@ namespace SolrNet.Tests
 			Assert.AreEqual("2.2", header.Params["version"]);
 		}
 
-		[Test]
-		public void ExtractResponse()
-		{
-			var parser = new ExtractResponseParser(new HeaderResponseParser<TestDocument>());
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithExtractContent.xml");
-			var extractResponse = parser.Parse(xml);
-			Assert.AreEqual("Hello world!", extractResponse.Content);
-		}
+        [Test]
+        public void ExtractResponse() {
+            var parser = new ExtractResponseParser(new HeaderResponseParser<TestDocument>());
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithExtractContent.xml");
+            var extractResponse = parser.Parse(xml);
+            Assert.AreEqual("Hello world!", extractResponse.Content);
+        }
 
-		private static IDictionary<string, HighlightedSnippets> ParseHighlightingResults(string rawXml)
-		{
-			var xml = XDocument.Parse(rawXml);
-			var docNode = xml.XPathSelectElement("response/lst[@name='highlighting']");
-			var item = new Product { Id = "SP2514N" };
-			return HighlightingResponseParser<Product>.ParseHighlighting(new SolrQueryResults<Product> { item }, docNode);
-		}
+        private static IDictionary<string, HighlightedSnippets> ParseHighlightingResults(string rawXml) {
+            var xml = XDocument.Parse(rawXml);
+            var docNode = xml.XPathSelectElement("response/lst[@name='highlighting']");
+            var item = new Product { Id = "SP2514N" };
+            return HighlightingResponseParser<Product>.ParseHighlighting(new SolrQueryResults<Product> { item }, docNode);
+        }
+
+        [Test]
+        public void ParseHighlighting() {
+            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
+            Assert.AreEqual(1, highlights.Count);
+            var kv = highlights.First().Value;
+            Assert.AreEqual(1, kv.Count);
+            Assert.AreEqual("features", kv.First().Key);
+            Assert.AreEqual(1, kv.First().Value.Count);
+            //Console.WriteLine(kv.First().Value.First());
+            Assert.Like(kv.First().Value.First(), "Noise");
+        }
 
 		[Test]
-		public void ParseHighlighting()
-		{
-			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
+		public void ParseHighlightingWrappedWithClass() {
+		    var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
 			Assert.AreEqual(1, highlights.Count);
-			var kv = highlights.First().Value;
-			Assert.AreEqual(1, kv.Count);
-			Assert.AreEqual("features", kv.First().Key);
-			Assert.AreEqual(1, kv.First().Value.Count);
-			//Console.WriteLine(kv.First().Value.First());
-			Assert.Like(kv.First().Value.First(), "Noise");
+		    var first = highlights.First();
+            Assert.AreEqual("SP2514N",first.Key);
+		    var fieldsWithSnippets = highlights["SP2514N"].Snippets;
+            Assert.AreEqual(1, fieldsWithSnippets.Count);
+            Assert.AreEqual("features", fieldsWithSnippets.First().Key);
+		    var snippets = highlights["SP2514N"].Snippets["features"];
+            Assert.AreEqual(1, snippets.Count);
+            Assert.Like(snippets.First(), "Noise");
 		}
 
-		[Test]
-		public void ParseHighlightingWrappedWithClass()
-		{
-			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
-			Assert.AreEqual(1, highlights.Count);
-			var first = highlights.First();
-			Assert.AreEqual("SP2514N", first.Key);
-			var fieldsWithSnippets = highlights["SP2514N"].Snippets;
-			Assert.AreEqual(1, fieldsWithSnippets.Count);
-			Assert.AreEqual("features", fieldsWithSnippets.First().Key);
-			var snippets = highlights["SP2514N"].Snippets["features"];
-			Assert.AreEqual(1, snippets.Count);
-			Assert.Like(snippets.First(), "Noise");
-		}
+        [Test]
+        public void ParseHighlighting2() {
+            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
+            var first = highlights.First();
+            //first.Value.Keys.ToList().ForEach(Console.WriteLine);
+            //first.Value["source_en"].ToList().ForEach(Console.WriteLine);
+            Assert.AreEqual(3, first.Value["source_en"].Count);
+        }
 
-		[Test]
-		public void ParseHighlighting2()
-		{
-			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
-			var first = highlights.First();
-			//first.Value.Keys.ToList().ForEach(Console.WriteLine);
-			//first.Value["source_en"].ToList().ForEach(Console.WriteLine);
-			Assert.AreEqual(3, first.Value["source_en"].Count);
-		}
+        [Test]
+        public void ParseHighlighting2WrappedWithClass()
+        {
+            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
+            var first = highlights.First();
+            //foreach (var i in first.Value.Snippets.Keys)
+            //    Console.WriteLine(i);
+            //foreach (var i in first.Value.Snippets["source_en"])
+            //    Console.WriteLine(i);
+            Assert.AreEqual(3, first.Value.Snippets["source_en"].Count);
+        }
 
-		[Test]
-		public void ParseHighlighting2WrappedWithClass()
-		{
-			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
-			var first = highlights.First();
-			//foreach (var i in first.Value.Snippets.Keys)
-			//    Console.WriteLine(i);
-			//foreach (var i in first.Value.Snippets["source_en"])
-			//    Console.WriteLine(i);
-			Assert.AreEqual(3, first.Value.Snippets["source_en"].Count);
-		}
+        [Test]
+        public void ParseHighlighting3() {
+            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting3.xml"));
+            Assert.AreEqual(0, highlights["e4420cc2"].Count);
+            Assert.AreEqual(1, highlights["e442c4cd"].Count);
+            Assert.AreEqual(1, highlights["e442c4cd"]["bodytext"].Count);
+            Assert.Contains(highlights["e442c4cd"]["bodytext"].First(), "Garia lancerer");
+        }
+        
+        [Test]
+        public void ParseSpellChecking() {
+            var parser = new SpellCheckResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+            var spellChecking = parser.ParseSpellChecking(docNode);
+            Assert.IsNotNull(spellChecking);
+            Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
+            Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
+            Assert.AreEqual(2, spellChecking.Collations.Count);
+        }
 
-		[Test]
-		public void ParseHighlighting3()
-		{
-			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting3.xml"));
-			Assert.AreEqual(0, highlights["e4420cc2"].Count);
-			Assert.AreEqual(1, highlights["e442c4cd"].Count);
-			Assert.AreEqual(1, highlights["e442c4cd"]["bodytext"].Count);
-			Assert.Contains(highlights["e442c4cd"]["bodytext"].First(), "Garia lancerer");
-		}
+        [Test]
+        public void ParseSpellChecking2()
+        {
+            var parser = new SpellCheckResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking2.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+            var spellChecking = parser.ParseSpellChecking(docNode);
+            Assert.IsNotNull(spellChecking);
+            Assert.AreEqual(2, spellChecking.Count);
+            Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
+            Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
+            Assert.AreEqual(2, spellChecking.Collations.Count);
+         }
 
-		[Test]
-		public void ParseSpellChecking()
-		{
-			var parser = new SpellCheckResponseParser<Product>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking.xml");
-			var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
-			var spellChecking = parser.ParseSpellChecking(docNode);
-			Assert.IsNotNull(spellChecking);
-			Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
-			Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
-			Assert.AreEqual(2, spellChecking.Collations.Count);
-		}
+        [Test]
+        public void ParseClustering() {
+            var parser = new ClusterResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithClustering.xml");
+            var docNode = xml.XPathSelectElement("response/arr[@name='clusters']");
+            var clustering = parser.ParseClusterNode(docNode);
+            Assert.IsNotNull(clustering);
+            Assert.AreEqual(89, clustering.Clusters.Count());
+            Assert.AreEqual("International", clustering.Clusters.First().Label);
+            Assert.AreEqual(33.729704170097, clustering.Clusters.First().Score);
+            Assert.AreEqual(8, clustering.Clusters.First().Documents.Count());
+            Assert.AreEqual("19622040", clustering.Clusters.First().Documents.First());
+        }
 
-		[Test]
-		public void ParseSpellChecking2()
-		{
-			var parser = new SpellCheckResponseParser<Product>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking2.xml");
-			var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
-			var spellChecking = parser.ParseSpellChecking(docNode);
-			Assert.IsNotNull(spellChecking);
-			Assert.AreEqual(2, spellChecking.Count);
-			Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
-			Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
-			Assert.AreEqual(2, spellChecking.Collations.Count);
-		}
-
-		[Test]
-		public void ParseClustering()
-		{
-			var parser = new ClusterResponseParser<Product>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithClustering.xml");
-			var docNode = xml.XPathSelectElement("response/arr[@name='clusters']");
-			var clustering = parser.ParseClusterNode(docNode);
-			Assert.IsNotNull(clustering);
-			Assert.AreEqual(89, clustering.Clusters.Count());
-			Assert.AreEqual("International", clustering.Clusters.First().Label);
-			Assert.AreEqual(33.729704170097, clustering.Clusters.First().Score);
-			Assert.AreEqual(8, clustering.Clusters.First().Documents.Count());
-			Assert.AreEqual("19622040", clustering.Clusters.First().Documents.First());
-		}
-
-		[Test]
-		public void ParseTerms()
-		{
-			var parser = new TermsResponseParser<Product>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTerms.xml");
-			var docNode = xml.XPathSelectElement("response/lst[@name='terms']");
-			var terms = parser.ParseTerms(docNode);
-			Assert.IsNotNull(terms);
-			Assert.AreEqual(2, terms.Count);
-			Assert.AreEqual("text", terms.First().Field);
-			Assert.AreEqual("textgen", terms.ElementAt(1).Field);
-			Assert.AreEqual("boot", terms.First().Terms.First().Key);
-			Assert.AreEqual(479, terms.First().Terms.First().Value);
-			Assert.AreEqual("boots", terms.ElementAt(1).Terms.First().Key);
-			Assert.AreEqual(463, terms.ElementAt(1).Terms.First().Value);
-		}
+        [Test]
+        public void ParseTerms()
+        {
+            var parser = new TermsResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTerms.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='terms']");
+            var terms = parser.ParseTerms(docNode);
+            Assert.IsNotNull(terms);
+            Assert.AreEqual(2, terms.Count);
+            Assert.AreEqual("text", terms.First().Field);
+            Assert.AreEqual("textgen", terms.ElementAt(1).Field);
+            Assert.AreEqual("boot", terms.First().Terms.First().Key);
+            Assert.AreEqual(479, terms.First().Terms.First().Value);
+            Assert.AreEqual("boots", terms.ElementAt(1).Terms.First().Key);
+            Assert.AreEqual(463, terms.ElementAt(1).Terms.First().Value);
+        }
 
 		[Test]
 		public void ParseTermVector()
@@ -629,183 +579,176 @@ namespace SolrNet.Tests
 
 			Assert.IsNotNull(docs);
 			Assert.AreEqual(2, docs.Count);
-			var cable = docs
-					.First(d => d.UniqueKey == "3007WFP")
-					.TermVector
-					.First(f => f.Field == "includes");
+            var cable = docs
+                .First(d => d.UniqueKey == "3007WFP")
+                .TermVector
+                .First(f => f.Field == "includes");
 
-			Assert.AreEqual("cable", cable.Term);
-			Assert.AreEqual(1, cable.Tf);
-			Assert.AreEqual(1, cable.Df);
+            Assert.AreEqual("cable", cable.Term);
+            Assert.AreEqual(1, cable.Tf);
+            Assert.AreEqual(1, cable.Df);
 			Assert.AreEqual(1.0, cable.Tf_Idf);
 
-			var positions = cable.Positions.ToList();
-			Assert.AreEqual(2, cable.Positions.Count);
-			Assert.AreEqual(1, positions[0]);
-			Assert.AreEqual(10, positions[1]);
+		    var positions = cable.Positions.ToList();
+            Assert.AreEqual(2, cable.Positions.Count);
+            Assert.AreEqual(1, positions[0]);
+            Assert.AreEqual(10, positions[1]);
 
-			var offsets = cable.Offsets.ToList();
-			Assert.AreEqual(1, cable.Offsets.Count);
-			Assert.AreEqual(4, offsets[0].Start);
-			Assert.AreEqual(9, offsets[0].End);
+		    var offsets = cable.Offsets.ToList();
+            Assert.AreEqual(1, cable.Offsets.Count);
+            Assert.AreEqual(4, offsets[0].Start);
+            Assert.AreEqual(9, offsets[0].End);
 		}
 
-		[Test]
-		public void ParseTermVector2()
-		{
-			var parser = new TermVectorResultsParser<Product>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTermVector2.xml");
-			var docNode = xml.XPathSelectElement("response/lst[@name='termVectors']");
-			var docs = parser.ParseDocuments(docNode).ToList();
-			Assert.IsNotNull(docs);
-			Assert.AreEqual(1, docs.Count);
-			Assert.AreEqual("20", docs[0].UniqueKey);
-			var vectors = docs[0].TermVector.ToList();
-			Assert.AreEqual(15, vectors.Count);
-		}
+        [Test]
+        public void ParseTermVector2() {
+            var parser = new TermVectorResultsParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTermVector2.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='termVectors']");
+            var docs = parser.ParseDocuments(docNode).ToList();
+            Assert.IsNotNull(docs);
+            Assert.AreEqual(1, docs.Count);
+            Assert.AreEqual("20", docs[0].UniqueKey);
+            var vectors = docs[0].TermVector.ToList();
+            Assert.AreEqual(15, vectors.Count);
+        }
+
+        [Test]
+        public void ParseMoreLikeThis() {
+            var mapper = new AttributesMappingManager();
+            var parser = new MoreLikeThisResponseParser<Product>(new SolrDocumentResponseParser<Product>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Product>()));
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMoreLikeThis.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='moreLikeThis']");
+            var product1 = new Product { Id = "UTF8TEST" };
+            var product2 = new Product { Id = "SOLR1000" };
+            var mlt = parser.ParseMoreLikeThis(new[] {
+                product1,
+                product2,
+            }, docNode);
+            Assert.IsNotNull(mlt);
+            Assert.AreEqual(2, mlt.Count);
+            Assert.IsTrue(mlt.ContainsKey(product1.Id));
+            Assert.IsTrue(mlt.ContainsKey(product2.Id));
+            Assert.AreEqual(1, mlt[product1.Id].Count);
+            Assert.AreEqual(1, mlt[product2.Id].Count);
+            //Console.WriteLine(mlt[product1.Id][0].Id);
+        }
+
+        [Test]
+        public void ParseStatsResults() {
+            var parser = new StatsResponseParser<Product>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithStats.xml");
+            var docNode = xml.XPathSelectElement("response/lst[@name='stats']");
+            var stats = parser.ParseStats(docNode, "stats_fields");
+            Assert.AreEqual(2, stats.Count);
+            Assert.IsTrue(stats.ContainsKey("price"));
+            var priceStats = stats["price"];
+            Assert.AreEqual(0.0, priceStats.Min);
+            Assert.AreEqual(2199.0, priceStats.Max);
+            Assert.AreEqual(5251.2699999999995, priceStats.Sum);
+            Assert.AreEqual(15, priceStats.Count);
+            Assert.AreEqual(11, priceStats.Missing);
+            Assert.AreEqual(6038619.160300001, priceStats.SumOfSquares);
+            Assert.AreEqual(350.08466666666664, priceStats.Mean);
+            Assert.AreEqual(547.737557906113, priceStats.StdDev);
+            Assert.AreEqual(1, priceStats.FacetResults.Count);
+            Assert.IsTrue(priceStats.FacetResults.ContainsKey("inStock"));
+            var priceInStockStats = priceStats.FacetResults["inStock"];
+            Assert.AreEqual(2, priceInStockStats.Count);
+            Assert.IsTrue(priceInStockStats.ContainsKey("true"));
+            Assert.IsTrue(priceInStockStats.ContainsKey("false"));
+            var priceInStockFalseStats = priceInStockStats["false"];
+            Assert.AreEqual(11.5, priceInStockFalseStats.Min);
+            Assert.AreEqual(649.99, priceInStockFalseStats.Max);
+            Assert.AreEqual(1161.39, priceInStockFalseStats.Sum);
+            Assert.AreEqual(4, priceInStockFalseStats.Count);
+            Assert.AreEqual(0, priceInStockFalseStats.Missing);
+            Assert.AreEqual(653369.2551, priceInStockFalseStats.SumOfSquares);
+            Assert.AreEqual(290.3475, priceInStockFalseStats.Mean);
+            Assert.AreEqual(324.63444676281654, priceInStockFalseStats.StdDev);
+            var priceInStockTrueStats = priceInStockStats["true"];
+            Assert.AreEqual(0.0, priceInStockTrueStats.Min);
+            Assert.AreEqual(2199.0, priceInStockTrueStats.Max);
+            Assert.AreEqual(4089.879999999999, priceInStockTrueStats.Sum);
+            Assert.AreEqual(11, priceInStockTrueStats.Count);
+            Assert.AreEqual(0, priceInStockTrueStats.Missing);
+            Assert.AreEqual(5385249.905200001, priceInStockTrueStats.SumOfSquares);
+            Assert.AreEqual(371.8072727272727, priceInStockTrueStats.Mean);
+            Assert.AreEqual(621.6592938755265, priceInStockTrueStats.StdDev);
+
+            var zeroResultsStats = stats["zeroResults"];
+            Assert.AreEqual(double.NaN, zeroResultsStats.Min);
+            Assert.AreEqual(double.NaN, zeroResultsStats.Max);
+            Assert.AreEqual(0, zeroResultsStats.Count);
+            Assert.AreEqual(0, zeroResultsStats.Missing);
+            Assert.AreEqual(0.0, zeroResultsStats.Sum);
+            Assert.AreEqual(0.0, zeroResultsStats.SumOfSquares);
+            Assert.AreEqual(double.NaN, zeroResultsStats.Mean);
+            Assert.AreEqual(0.0, zeroResultsStats.StdDev);
+        }
+
+        [Test]
+        public void ParseStatsResults2() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithStats.xml");
+            var parser = new StatsResponseParser<Product>();
+            var stats = parser.ParseStats(xml.Root, "stats_fields");
+
+            Assert.IsNotNull(stats);
+            Assert.Contains(stats.Keys, "instock_prices");
+            Assert.Contains(stats.Keys, "all_prices");
+
+            var instock = stats["instock_prices"];
+            Assert.AreEqual(0, instock.Min);
+            Assert.AreEqual(2199, instock.Max);
+            Assert.AreEqual(16, instock.Count);
+            Assert.AreEqual(16, instock.Missing);
+            Assert.AreEqual(5251.270030975342, instock.Sum);
+
+            var all = stats["all_prices"];
+            Assert.AreEqual(4089.880027770996, all.Sum);
+            Assert.AreEqual(2199, all.Max);
+        }
+
+        [Test]
+        public void ParseFacetDateResults() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacet.xml");
+            var p = new FacetsResponseParser<Product>();
+            var results = p.ParseFacetDates(xml.Root);
+            Assert.AreEqual(1, results.Count);
+            var result = results.First();
+            Assert.AreEqual("timestamp", result.Key);
+            Assert.AreEqual("+1DAY", result.Value.Gap);
+            Assert.AreEqual(new DateTime(2009, 8, 10, 0, 33, 46, 578), result.Value.End);
+            var dateResults = result.Value.DateResults;
+            Assert.AreEqual(1, dateResults.Count);
+            Assert.AreEqual(16, dateResults[0].Value);
+            Assert.AreEqual(new DateTime(2009, 8, 9, 0, 33, 46, 578), dateResults[0].Key);
+        }
+
+        [Test]
+        public void ParseFacetDateResultsWithOther() {
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacetAndOther.xml");
+            var p = new FacetsResponseParser<Product>();
+            var results = p.ParseFacetDates(xml.Root);
+            Assert.AreEqual(1, results.Count);
+            var result = results.First();
+            Assert.AreEqual("timestamp", result.Key);
+            Assert.AreEqual("+1DAY", result.Value.Gap);
+            Assert.AreEqual(new DateTime(2009, 8, 10, 0, 46, 29), result.Value.End);
+            Assert.AreEqual(new DateTime(2009, 8, 9, 22, 46, 29), result.Value.DateResults[0].Key);
+            var other = result.Value.OtherResults;
+            Assert.AreEqual(1, other[FacetDateOther.Before]);
+            Assert.AreEqual(0, other[FacetDateOther.After]);
+            Assert.AreEqual(0, other[FacetDateOther.Between]);
+        }
 
 		[Test]
-		public void ParseMoreLikeThis()
-		{
-			var mapper = new AttributesMappingManager();
-			var parser = new MoreLikeThisResponseParser<Product>(new SolrDocumentResponseParser<Product>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Product>()));
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMoreLikeThis.xml");
-			var docNode = xml.XPathSelectElement("response/lst[@name='moreLikeThis']");
-			var product1 = new Product { Id = "UTF8TEST" };
-			var product2 = new Product { Id = "SOLR1000" };
-			var mlt = parser.ParseMoreLikeThis(new[] {
-								product1,
-								product2,
-						}, docNode);
-			Assert.IsNotNull(mlt);
-			Assert.AreEqual(2, mlt.Count);
-			Assert.IsTrue(mlt.ContainsKey(product1.Id));
-			Assert.IsTrue(mlt.ContainsKey(product2.Id));
-			Assert.AreEqual(1, mlt[product1.Id].Count);
-			Assert.AreEqual(1, mlt[product2.Id].Count);
-			//Console.WriteLine(mlt[product1.Id][0].Id);
-		}
-
-		[Test]
-		public void ParseStatsResults()
-		{
-			var parser = new StatsResponseParser<Product>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithStats.xml");
-			var docNode = xml.XPathSelectElement("response/lst[@name='stats']");
-			var stats = parser.ParseStats(docNode, "stats_fields");
-			Assert.AreEqual(2, stats.Count);
-			Assert.IsTrue(stats.ContainsKey("price"));
-			var priceStats = stats["price"];
-			Assert.AreEqual(0.0, priceStats.Min);
-			Assert.AreEqual(2199.0, priceStats.Max);
-			Assert.AreEqual(5251.2699999999995, priceStats.Sum);
-			Assert.AreEqual(15, priceStats.Count);
-			Assert.AreEqual(11, priceStats.Missing);
-			Assert.AreEqual(6038619.160300001, priceStats.SumOfSquares);
-			Assert.AreEqual(350.08466666666664, priceStats.Mean);
-			Assert.AreEqual(547.737557906113, priceStats.StdDev);
-			Assert.AreEqual(1, priceStats.FacetResults.Count);
-			Assert.IsTrue(priceStats.FacetResults.ContainsKey("inStock"));
-			var priceInStockStats = priceStats.FacetResults["inStock"];
-			Assert.AreEqual(2, priceInStockStats.Count);
-			Assert.IsTrue(priceInStockStats.ContainsKey("true"));
-			Assert.IsTrue(priceInStockStats.ContainsKey("false"));
-			var priceInStockFalseStats = priceInStockStats["false"];
-			Assert.AreEqual(11.5, priceInStockFalseStats.Min);
-			Assert.AreEqual(649.99, priceInStockFalseStats.Max);
-			Assert.AreEqual(1161.39, priceInStockFalseStats.Sum);
-			Assert.AreEqual(4, priceInStockFalseStats.Count);
-			Assert.AreEqual(0, priceInStockFalseStats.Missing);
-			Assert.AreEqual(653369.2551, priceInStockFalseStats.SumOfSquares);
-			Assert.AreEqual(290.3475, priceInStockFalseStats.Mean);
-			Assert.AreEqual(324.63444676281654, priceInStockFalseStats.StdDev);
-			var priceInStockTrueStats = priceInStockStats["true"];
-			Assert.AreEqual(0.0, priceInStockTrueStats.Min);
-			Assert.AreEqual(2199.0, priceInStockTrueStats.Max);
-			Assert.AreEqual(4089.879999999999, priceInStockTrueStats.Sum);
-			Assert.AreEqual(11, priceInStockTrueStats.Count);
-			Assert.AreEqual(0, priceInStockTrueStats.Missing);
-			Assert.AreEqual(5385249.905200001, priceInStockTrueStats.SumOfSquares);
-			Assert.AreEqual(371.8072727272727, priceInStockTrueStats.Mean);
-			Assert.AreEqual(621.6592938755265, priceInStockTrueStats.StdDev);
-
-			var zeroResultsStats = stats["zeroResults"];
-			Assert.AreEqual(double.NaN, zeroResultsStats.Min);
-			Assert.AreEqual(double.NaN, zeroResultsStats.Max);
-			Assert.AreEqual(0, zeroResultsStats.Count);
-			Assert.AreEqual(0, zeroResultsStats.Missing);
-			Assert.AreEqual(0.0, zeroResultsStats.Sum);
-			Assert.AreEqual(0.0, zeroResultsStats.SumOfSquares);
-			Assert.AreEqual(double.NaN, zeroResultsStats.Mean);
-			Assert.AreEqual(0.0, zeroResultsStats.StdDev);
-		}
-
-		[Test]
-		public void ParseStatsResults2()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithStats.xml");
-			var parser = new StatsResponseParser<Product>();
-			var stats = parser.ParseStats(xml.Root, "stats_fields");
-
-			Assert.IsNotNull(stats);
-			Assert.Contains(stats.Keys, "instock_prices");
-			Assert.Contains(stats.Keys, "all_prices");
-
-			var instock = stats["instock_prices"];
-			Assert.AreEqual(0, instock.Min);
-			Assert.AreEqual(2199, instock.Max);
-			Assert.AreEqual(16, instock.Count);
-			Assert.AreEqual(16, instock.Missing);
-			Assert.AreEqual(5251.270030975342, instock.Sum);
-
-			var all = stats["all_prices"];
-			Assert.AreEqual(4089.880027770996, all.Sum);
-			Assert.AreEqual(2199, all.Max);
-		}
-
-		[Test]
-		public void ParseFacetDateResults()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacet.xml");
-			var p = new FacetsResponseParser<Product>();
-			var results = p.ParseFacetDates(xml.Root);
-			Assert.AreEqual(1, results.Count);
-			var result = results.First();
-			Assert.AreEqual("timestamp", result.Key);
-			Assert.AreEqual("+1DAY", result.Value.Gap);
-			Assert.AreEqual(new DateTime(2009, 8, 10, 0, 33, 46, 578), result.Value.End);
-			var dateResults = result.Value.DateResults;
-			Assert.AreEqual(1, dateResults.Count);
-			Assert.AreEqual(16, dateResults[0].Value);
-			Assert.AreEqual(new DateTime(2009, 8, 9, 0, 33, 46, 578), dateResults[0].Key);
-		}
-
-		[Test]
-		public void ParseFacetDateResultsWithOther()
-		{
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacetAndOther.xml");
-			var p = new FacetsResponseParser<Product>();
-			var results = p.ParseFacetDates(xml.Root);
-			Assert.AreEqual(1, results.Count);
-			var result = results.First();
-			Assert.AreEqual("timestamp", result.Key);
-			Assert.AreEqual("+1DAY", result.Value.Gap);
-			Assert.AreEqual(new DateTime(2009, 8, 10, 0, 46, 29), result.Value.End);
-			Assert.AreEqual(new DateTime(2009, 8, 9, 22, 46, 29), result.Value.DateResults[0].Key);
-			var other = result.Value.OtherResults;
-			Assert.AreEqual(1, other[FacetDateOther.Before]);
-			Assert.AreEqual(0, other[FacetDateOther.After]);
-			Assert.AreEqual(0, other[FacetDateOther.Between]);
-		}
-
-		[Test]
-		public void ParseResultsWithGroups()
-		{
+		public void ParseResultsWithGroups() {
 			var mapper = new AttributesMappingManager();
 			var parser = new GroupingResponseParser<Product>(new SolrDocumentResponseParser<Product>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Product>()));
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithGroupingOnInstock.xml");
-			var results = new SolrQueryResults<Product>();
-			parser.Parse(xml, results);
+		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithGroupingOnInstock.xml");
+		    var results = new SolrQueryResults<Product>();
+		    parser.Parse(xml, results);
 			Assert.AreEqual(1, results.Grouping.Count);
 			Assert.AreEqual(2, results.Grouping["inStock"].Groups.Count());
 			Assert.AreEqual(13, results.Grouping["inStock"].Groups.First().NumFound);
@@ -815,92 +758,88 @@ namespace SolrNet.Tests
 		public void ParseResultsWithFacetPivot()
 		{
 			var parser = new FacetsResponseParser<Product>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacetPivoting.xml");
-			var r = new SolrQueryResults<Product>();
-			parser.Parse(xml, r);
+		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacetPivoting.xml");
+		    var r = new SolrQueryResults<Product>();
+		    parser.Parse(xml, r);
 			Assert.IsNotNull(r.FacetPivots);
 			//Console.WriteLine(r.FacetPivots.Count);
 			Assert.IsTrue(r.FacetPivots.ContainsKey("inStock,manu"));
 
 			Assert.AreEqual(2, r.FacetPivots["inStock,manu"].Count);
 			Assert.AreEqual("inStock", r.FacetPivots["inStock,manu"][0].Field);
-			Assert.AreEqual(10, r.FacetPivots["inStock,manu"][0].ChildPivots.Count);
+			Assert.AreEqual(10, r.FacetPivots["inStock,manu"][0].ChildPivots.Count); 
 
-		}
+		} 
 
-		[Test]
-		public void PropertyWithoutSetter()
-		{
-			var parser = GetDocumentParser<TestDocWithoutSetter>();
-			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-			var docNode = xml.XPathSelectElement("response/result/doc");
-			var docs = parser.ParseDocument(docNode).ToList();
-			Assert.IsTrue(docs.Count > 0);
-			Assert.AreEqual(0, docs[0].Id);
-		}
+        [Test]
+        public void PropertyWithoutSetter() {
+            var parser = GetDocumentParser<TestDocWithoutSetter>();
+            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+            var docNode = xml.XPathSelectElement("response/result/doc");
+            var doc = parser.ParseDocument(docNode).ToList();
+            Assert.IsNotNull(doc);
+            Assert.AreEqual(0, doc[0].Id);
+        }
 
-		[Test]
-		public void ParseInterestingTermsList()
-		{
-			var innerParser = new InterestingTermsResponseParser<Product>();
-			var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
-			var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsList.xml");
-			var results = parser.Parse(response);
+        [Test]
+        public void ParseInterestingTermsList()
+        {
+            var innerParser = new InterestingTermsResponseParser<Product>();
+            var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
+            var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsList.xml");
+            var results = parser.Parse(response);
 
-			Assert.IsNotNull(results);
-			Assert.IsNotNull(results.InterestingTerms);
-			Assert.AreEqual(4, results.InterestingTerms.Count);
-			Assert.AreEqual("three", results.InterestingTerms[2].Key);
-			Assert.IsTrue(results.InterestingTerms.All(t => t.Value == 0.0f));
-		}
+            Assert.IsNotNull(results);
+            Assert.IsNotNull(results.InterestingTerms);
+            Assert.AreEqual(4, results.InterestingTerms.Count);
+            Assert.AreEqual("three", results.InterestingTerms[2].Key);
+            Assert.IsTrue(results.InterestingTerms.All(t => t.Value == 0.0f));
+        }
 
-		[Test]
-		public void ParseInterestingTermsDetails()
-		{
-			var innerParser = new InterestingTermsResponseParser<Product>();
-			var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
-			var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
-			var results = parser.Parse(response);
+        [Test]
+        public void ParseInterestingTermsDetails()
+        {
+            var innerParser = new InterestingTermsResponseParser<Product>();
+            var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
+            var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
+            var results = parser.Parse(response);
 
-			Assert.IsNotNull(results);
-			Assert.IsNotNull(results.InterestingTerms);
-			Assert.AreEqual(4, results.InterestingTerms.Count);
-			Assert.AreEqual("content:three", results.InterestingTerms[2].Key);
-			Assert.AreEqual(3.3f, results.InterestingTerms[2].Value);
-		}
+            Assert.IsNotNull(results);
+            Assert.IsNotNull(results.InterestingTerms);
+            Assert.AreEqual(4, results.InterestingTerms.Count);
+            Assert.AreEqual("content:three", results.InterestingTerms[2].Key);
+            Assert.AreEqual(3.3f, results.InterestingTerms[2].Value);
+        }
 
-		[Test]
-		public void ParseMlthMatch()
-		{
-			var innerParser = new MoreLikeThisHandlerMatchResponseParser<TestDocWithGuid>(GetDocumentParser<TestDocWithGuid>());
-			var parser = new SolrMoreLikeThisHandlerQueryResultsParser<TestDocWithGuid>(new[] { innerParser });
-			var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
-			var results = parser.Parse(response);
+        [Test]
+        public void ParseMlthMatch()
+        {
+            var innerParser = new MoreLikeThisHandlerMatchResponseParser<TestDocWithGuid>(GetDocumentParser<TestDocWithGuid>());
+            var parser = new SolrMoreLikeThisHandlerQueryResultsParser<TestDocWithGuid>(new[] { innerParser });
+            var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
+            var results = parser.Parse(response);
 
-			Assert.IsNotNull(results);
-			Assert.IsNotNull(results.Match);
-			Assert.AreEqual(new Guid("224fbdc1-12df-4520-9fbe-dd91f916eba1"), results.Match.Key);
-		}
+            Assert.IsNotNull(results);
+            Assert.IsNotNull(results.Match);
+            Assert.AreEqual(new Guid("224fbdc1-12df-4520-9fbe-dd91f916eba1"), results.Match.Key);
+        }
 
-		public enum AEnum
-		{
-			One,
-			Two,
-			Three
-		}
+        public enum AEnum {
+            One,
+            Two,
+            Three
+        }
 
+        
 
+        public class TestDocWithEnum {
+            [SolrField]
+            public AEnum En { get; set; }
+        }
 
-		public class TestDocWithEnum
-		{
-			[SolrField]
-			public AEnum En { get; set; }
-		}
-
-		public class TestDocWithNullableEnum
-		{
-			[SolrField("basicview")]
-			public AEnum? BasicView { get; set; }
-		}
+        public class TestDocWithNullableEnum {
+            [SolrField("basicview")]
+            public AEnum? BasicView { get; set; }
+        }
 	}
 }

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -60,6 +60,45 @@ namespace SolrNet.Tests
 		}
 
 		[Test]
+		public void ParseDocumentWithChildren()
+		{
+			var parser = GetDocumentParser<TestDocumentWithChildren>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMultipleChildren.xml");
+			var docNode = xml.XPathSelectElement("response/result/doc");
+			var docs = parser.ParseDocument(docNode).ToList();
+			Assert.AreEqual(2, docs.Count);
+			Assert.AreEqual(123456, docs[0].Id);
+			Assert.AreEqual(123456, docs[1].Id);
+
+			Assert.AreEqual("abcdef", docs[0].ChildField);
+			Assert.AreEqual("wxyz", docs[1].ChildField);
+
+			Assert.AreEqual("child value", docs[0].SameFieldName);
+			Assert.AreEqual("child value", docs[1].SameFieldName);
+		}
+
+		[Test]
+		public void ParseResultsWithChildren()
+		{
+			var parser = GetDocumentParser<TestDocumentWithChildren>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMultipleChildren.xml");
+			var resultNode = xml.XPathSelectElement("response/result");
+			var docs = parser.ParseResults(resultNode).ToList();
+			Assert.AreEqual(3, docs.Count);
+			Assert.AreEqual(123456, docs[0].Id);
+			Assert.AreEqual(123456, docs[1].Id);
+			Assert.AreEqual(789, docs[2].Id);
+
+			Assert.AreEqual("abcdef", docs[0].ChildField);
+			Assert.AreEqual("wxyz", docs[1].ChildField);
+			Assert.IsNull(docs[2].ChildField);
+
+			Assert.AreEqual("child value", docs[0].SameFieldName);
+			Assert.AreEqual("child value", docs[1].SameFieldName);
+			Assert.AreEqual("parent value", docs[2].SameFieldName);
+		}
+
+		[Test]
 		public void ParseDocumentWithMappingManager()
 		{
 			var mapper = new MappingManager();

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -31,78 +31,88 @@ using SolrNet.Mapping;
 using SolrNet.Tests.Utils;
 using Castle.Facilities.SolrNetIntegration;
 
-namespace SolrNet.Tests {
+namespace SolrNet.Tests
+{
 	[TestFixture]
-	public partial class SolrQueryResultsParserTests {
+	public partial class SolrQueryResultsParserTests
+	{
 
-        private static SolrDocumentResponseParser<T> GetDocumentParser<T>() {
-            var mapper = new AttributesMappingManager();
-            return GetDocumentParser<T>(mapper);
-        }
-
-        private static SolrDocumentResponseParser<T> GetDocumentParser<T>(IReadOnlyMappingManager mapper) {
-            return new SolrDocumentResponseParser<T>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<T>());
-        }
-
-		[Test]
-		public void ParseDocument() {
-            var parser = GetDocumentParser<TestDocument>();
-		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-            var docNode = xml.XPathSelectElement("response/result/doc");
-			var doc = parser.ParseDocument(docNode);
-			Assert.IsNotNull(doc);
-			Assert.AreEqual(123456, doc.Id);
+		private static SolrDocumentResponseParser<T> GetDocumentParser<T>()
+		{
+			var mapper = new AttributesMappingManager();
+			return GetDocumentParser<T>(mapper);
 		}
 
-        [Test]
-	    public void ParseDocumentWithMappingManager() {
-            var mapper = new MappingManager();
-            mapper.Add(typeof(TestDocumentWithoutAttributes).GetProperty("Id"), "id");
-            var parser = GetDocumentParser<TestDocumentWithoutAttributes>(mapper);
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-            var docNode = xml.XPathSelectElement("response/result/doc");
-            var doc = parser.ParseDocument(docNode);
-			Assert.IsNotNull(doc);
-			Assert.AreEqual(123456, doc.Id);
-	    }
-
-        private static SolrQueryResults<T> ParseFromResource<T>(string xmlResource) {
-            var docParser = GetDocumentParser<T>();
-            var parser = new ResultsResponseParser<T>(docParser);
-            var r = new SolrQueryResults<T>();
-            var xml = EmbeddedResource.GetEmbeddedXml(typeof(SolrQueryResultsParserTests), xmlResource);
-            parser.Parse(xml, r);
-            return r;
-        }
+		private static SolrDocumentResponseParser<T> GetDocumentParser<T>(IReadOnlyMappingManager mapper)
+		{
+			return new SolrDocumentResponseParser<T>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<T>());
+		}
 
 		[Test]
-		public void NumFound() {
-		    var r = ParseFromResource<TestDocument>("Resources.response.xml");
+		public void ParseDocument()
+		{
+			var parser = GetDocumentParser<TestDocument>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+			var docNode = xml.XPathSelectElement("response/result/doc");
+			var docs = parser.ParseDocument(docNode).ToList();
+			Assert.IsTrue(docs.Count > 0);
+			Assert.AreEqual(123456, docs[0].Id);
+		}
+
+		[Test]
+		public void ParseDocumentWithMappingManager()
+		{
+			var mapper = new MappingManager();
+			mapper.Add(typeof(TestDocumentWithoutAttributes).GetProperty("Id"), "id");
+			var parser = GetDocumentParser<TestDocumentWithoutAttributes>(mapper);
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+			var docNode = xml.XPathSelectElement("response/result/doc");
+			var docs = parser.ParseDocument(docNode).ToList();
+			Assert.IsTrue(docs.Count > 0);
+			Assert.AreEqual(123456, docs[0].Id);
+		}
+
+		private static SolrQueryResults<T> ParseFromResource<T>(string xmlResource)
+		{
+			var docParser = GetDocumentParser<T>();
+			var parser = new ResultsResponseParser<T>(docParser);
+			var r = new SolrQueryResults<T>();
+			var xml = EmbeddedResource.GetEmbeddedXml(typeof(SolrQueryResultsParserTests), xmlResource);
+			parser.Parse(xml, r);
+			return r;
+		}
+
+		[Test]
+		public void NumFound()
+		{
+			var r = ParseFromResource<TestDocument>("Resources.response.xml");
 			Assert.AreEqual(1, r.NumFound);
 		}
 
-        [Test]
-        public void CanParseNextCursormark()
-        {
-            var r = ParseFromResource<TestDocument>("Resources.response.xml");
-            Assert.AreEqual(new StartOrCursor.Cursor("AoEoZTQ3YmY0NDM="), r.NextCursorMark);
-        }
+		[Test]
+		public void CanParseNextCursormark()
+		{
+			var r = ParseFromResource<TestDocument>("Resources.response.xml");
+			Assert.AreEqual(new StartOrCursor.Cursor("AoEoZTQ3YmY0NDM="), r.NextCursorMark);
+		}
 
 		[Test]
-		public void Parse() {
-		    var results = ParseFromResource<TestDocument>("Resources.response.xml");
-    		Assert.AreEqual(1, results.Count);
+		public void Parse()
+		{
+			var results = ParseFromResource<TestDocument>("Resources.response.xml");
+			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(123456, doc.Id);
 		}
 
 		[Test]
-		public void SetPropertyWithArrayOfStrings() {
-		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='cat']");
-            var mapper = new AttributesMappingManager();
-		    var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-            var doc = new TestDocumentWithArrays();
+		public void SetPropertyWithArrayOfStrings()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='cat']");
+			var mapper = new AttributesMappingManager();
+			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+			var doc = new TestDocumentWithArrays();
 			visitor.Visit(doc, "cat", fieldNode);
 			Assert.AreEqual(2, doc.Cat.Count);
 			var cats = new List<string>(doc.Cat);
@@ -111,35 +121,38 @@ namespace SolrNet.Tests {
 		}
 
 		[Test]
-		public void SetPropertyDouble() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-            var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
-            var mapper = new AttributesMappingManager();
-            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-            var doc = new TestDocumentWithArrays();
-            visitor.Visit(doc, "price", fieldNode);
+		public void SetPropertyDouble()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+			var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
+			var mapper = new AttributesMappingManager();
+			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+			var doc = new TestDocumentWithArrays();
+			visitor.Visit(doc, "price", fieldNode);
 			Assert.AreEqual(92d, doc.Price);
 		}
 
 		[Test]
-		public void SetPropertyNullableDouble() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-            var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
-            var mapper = new AttributesMappingManager();
-            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-            var doc = new TestDocumentWithNullableDouble();
-            visitor.Visit(doc, "price", fieldNode);
+		public void SetPropertyNullableDouble()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+			var fieldNode = xml.XPathSelectElement("response/result/doc/float[@name='price']");
+			var mapper = new AttributesMappingManager();
+			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+			var doc = new TestDocumentWithNullableDouble();
+			visitor.Visit(doc, "price", fieldNode);
 			Assert.AreEqual(92d, doc.Price);
 		}
 
 		[Test]
-		public void SetPropertyWithIntCollection() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
-            var mapper = new AttributesMappingManager();
-            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-            var doc = new TestDocumentWithArrays();
-            visitor.Visit(doc, "numbers", fieldNode);
+		public void SetPropertyWithIntCollection()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
+			var mapper = new AttributesMappingManager();
+			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+			var doc = new TestDocumentWithArrays();
+			visitor.Visit(doc, "numbers", fieldNode);
 			Assert.AreEqual(2, doc.Numbers.Count);
 			var numbers = new List<int>(doc.Numbers);
 			Assert.AreEqual(1, numbers[0]);
@@ -147,13 +160,14 @@ namespace SolrNet.Tests {
 		}
 
 		[Test]
-		public void SetPropertyWithNonGenericCollection() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
-            var mapper = new AttributesMappingManager();
-            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-            var doc = new TestDocumentWithArrays3();
-            visitor.Visit(doc, "numbers", fieldNode);
+		public void SetPropertyWithNonGenericCollection()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
+			var mapper = new AttributesMappingManager();
+			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+			var doc = new TestDocumentWithArrays3();
+			visitor.Visit(doc, "numbers", fieldNode);
 			Assert.AreEqual(2, doc.Numbers.Count);
 			var numbers = new ArrayList(doc.Numbers);
 			Assert.AreEqual(1, numbers[0]);
@@ -161,13 +175,14 @@ namespace SolrNet.Tests {
 		}
 
 		[Test]
-		public void SetPropertyWithArrayOfIntsToIntArray() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
-            var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
-            var mapper = new AttributesMappingManager();
-            var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
-            var doc = new TestDocumentWithArrays2();
-            visitor.Visit(doc, "numbers", fieldNode);
+		public void SetPropertyWithArrayOfIntsToIntArray()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArrays.xml");
+			var fieldNode = xml.XPathSelectElement("response/result/doc/arr[@name='numbers']");
+			var mapper = new AttributesMappingManager();
+			var visitor = new DefaultDocumentVisitor(mapper, new DefaultFieldParser());
+			var doc = new TestDocumentWithArrays2();
+			visitor.Visit(doc, "numbers", fieldNode);
 			Assert.AreEqual(2, doc.Numbers.Length);
 			var numbers = new List<int>(doc.Numbers);
 			Assert.AreEqual(1, numbers[0]);
@@ -175,216 +190,240 @@ namespace SolrNet.Tests {
 		}
 
 		[Test]
-		public void ParseResultsWithArrays() {
-		    var results = ParseFromResource<TestDocumentWithArrays>("Resources.responseWithArrays.xml");
+		public void ParseResultsWithArrays()
+		{
+			var results = ParseFromResource<TestDocumentWithArrays>("Resources.responseWithArrays.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual("SP2514N", doc.Id);
 		}
 
 		[Test]
-		public void SupportsDateTime() {
-		    var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithDate.xml");
+		public void SupportsDateTime()
+		{
+			var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithDate.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5), doc.Fecha);
 		}
 
 		[Test]
-		public void ParseDate_without_milliseconds() {
-            var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05Z");
+		public void ParseDate_without_milliseconds()
+		{
+			var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05Z");
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5), dt);
 		}
 
 		[Test]
-		public void ParseDate_with_milliseconds() {
-            var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05.245Z");
+		public void ParseDate_with_milliseconds()
+		{
+			var dt = DateTimeFieldParser.ParseDate("2001-01-02T03:04:05.245Z");
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5, 245), dt);
 		}
 
 		[Test]
-		public void SupportsNullableDateTime() {
-		    var results = ParseFromResource<TestDocumentWithNullableDate>("Resources.responseWithDate.xml");
+		public void SupportsNullableDateTime()
+		{
+			var results = ParseFromResource<TestDocumentWithNullableDate>("Resources.responseWithDate.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(new DateTime(2001, 1, 2, 3, 4, 5), doc.Fecha);
 		}
 
 		[Test]
-		public void SupportsIEnumerable() {
-            var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
+		public void SupportsIEnumerable()
+		{
+			var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 			Assert.AreEqual(2, new List<string>(doc.Features).Count);
 		}
 
-        [Test]
-        public void SupportsGuid() {
-            var results = ParseFromResource<TestDocWithGuid>("Resources.responseWithGuid.xml");
-            Assert.AreEqual(1, results.Count);
-            var doc = results[0];
-            //Console.WriteLine(doc.Key);
-        }
-
-        [Test]
-        public void SupportsEnumAsInteger() {
-            var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsInt.xml");
-            Assert.AreEqual(1, results.Count);
-            var doc = results[0];
-            //Console.WriteLine(doc.En);
-        }
-
-        [Test]
-        public void SupportsEnumAsString() {
-            var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsString.xml");
-            Assert.AreEqual(1, results.Count);
-            var doc = results[0];
-            //Console.WriteLine(doc.En);
-        }
-
-        [Test]
-        [ExpectedException(typeof(Exception))]
-        public void EmptyEnumThrows() {
-            var mapper = new MappingManager();
-            mapper.Add(typeof(TestDocWithEnum).GetProperty("En"), "basicview");
-            var docParser = GetDocumentParser<TestDocWithEnum>(mapper);
-            var parser = new ResultsResponseParser<TestDocWithEnum>(docParser);
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-            var results = new SolrQueryResults<TestDocWithEnum>();
-            parser.Parse(xml, results);
-        }
-
-        [Test]
-        public void SupportsNullableGuidWithEmptyField() {
-            var results = ParseFromResource<TestDocWithNullableEnum>("Resources.response.xml");
-            Assert.AreEqual(1, results.Count);
-            Assert.IsFalse(results[0].BasicView.HasValue);
-        }
-
-        [Test]
-        public void GenericDictionary_string_string() {
-            var results = ParseFromResource<TestDocWithGenDict>("Resources.responseWithDict.xml");
-            Assert.AreEqual(1, results.Count);
-            var doc = results[0];
-            Assert.IsNotNull(doc.Dict);
-            Assert.AreEqual(2, doc.Dict.Count);
-            Assert.AreEqual("1", doc.Dict["One"]);
-            Assert.AreEqual("2", doc.Dict["Two"]);
-        }
-
-        [Test]
-        public void GenericDictionary_string_int() {
-            var results = ParseFromResource<TestDocWithGenDict2>("Resources.responseWithDict.xml");
-            Assert.AreEqual(1, results.Count);
-            var doc = results[0];
-            Assert.IsNotNull(doc.Dict);
-            Assert.AreEqual(2, doc.Dict.Count);
-            Assert.AreEqual(1, doc.Dict["One"]);
-            Assert.AreEqual(2, doc.Dict["Two"]);
-        }
-
-        [Test]
-        public void GenericDictionary_string_float() {
-            var results = ParseFromResource<TestDocWithGenDict3>("Resources.responseWithDictFloat.xml");
-            Assert.AreEqual(1, results.Count);
-            var doc = results[0];
-            Assert.IsNotNull(doc.Dict);
-            Assert.AreEqual(2, doc.Dict.Count);
-            Assert.AreEqual(1.45f, doc.Dict["One"]);
-            Assert.AreEqual(2.234f, doc.Dict["Two"]);
-        }
-
-        [Test]
-        public void GenericDictionary_string_decimal() {
-            var results = ParseFromResource<TestDocWithGenDict4>("Resources.responseWithDictFloat.xml");
-            Assert.AreEqual(1, results.Count);
-            var doc = results[0];
-            Assert.IsNotNull(doc.Dict);
-            Assert.AreEqual(2, doc.Dict.Count);
-            Assert.AreEqual(1.45m, doc.Dict["One"]);
-            Assert.AreEqual(2.234m, doc.Dict["Two"]);
-        }
-
-        [Test]
-        public void GenericDictionary_rest_of_fields() {
-            var results = ParseFromResource<TestDocWithGenDict5>("Resources.responseWithDictFloat.xml");
-            Assert.AreEqual("1.45", results[0].DictOne);
-            Assert.IsNotNull(results[0].Dict);
-            Assert.AreEqual(4, results[0].Dict.Count);
-            Assert.AreEqual("2.234", results[0].Dict["DictTwo"]);
-            Assert.AreEqual(new DateTime(1, 1, 1), results[0].Dict["timestamp"]);
-            Assert.AreEqual(92.0f, results[0].Dict["price"]);
-            Assert.IsInstanceOfType(typeof(ICollection), results[0].Dict["features"]);
-        }
+		[Test]
+		public void SupportsGuid()
+		{
+			var results = ParseFromResource<TestDocWithGuid>("Resources.responseWithGuid.xml");
+			Assert.AreEqual(1, results.Count);
+			var doc = results[0];
+			//Console.WriteLine(doc.Key);
+		}
 
 		[Test]
-		public void WrongFieldDoesntThrow() {
-            var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithArraysSimple.xml");
+		public void SupportsEnumAsInteger()
+		{
+			var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsInt.xml");
+			Assert.AreEqual(1, results.Count);
+			var doc = results[0];
+			//Console.WriteLine(doc.En);
+		}
+
+		[Test]
+		public void SupportsEnumAsString()
+		{
+			var results = ParseFromResource<TestDocWithEnum>("Resources.responseWithEnumAsString.xml");
+			Assert.AreEqual(1, results.Count);
+			var doc = results[0];
+			//Console.WriteLine(doc.En);
+		}
+
+		[Test]
+		[ExpectedException(typeof(Exception))]
+		public void EmptyEnumThrows()
+		{
+			var mapper = new MappingManager();
+			mapper.Add(typeof(TestDocWithEnum).GetProperty("En"), "basicview");
+			var docParser = GetDocumentParser<TestDocWithEnum>(mapper);
+			var parser = new ResultsResponseParser<TestDocWithEnum>(docParser);
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+			var results = new SolrQueryResults<TestDocWithEnum>();
+			parser.Parse(xml, results);
+		}
+
+		[Test]
+		public void SupportsNullableGuidWithEmptyField()
+		{
+			var results = ParseFromResource<TestDocWithNullableEnum>("Resources.response.xml");
+			Assert.AreEqual(1, results.Count);
+			Assert.IsFalse(results[0].BasicView.HasValue);
+		}
+
+		[Test]
+		public void GenericDictionary_string_string()
+		{
+			var results = ParseFromResource<TestDocWithGenDict>("Resources.responseWithDict.xml");
+			Assert.AreEqual(1, results.Count);
+			var doc = results[0];
+			Assert.IsNotNull(doc.Dict);
+			Assert.AreEqual(2, doc.Dict.Count);
+			Assert.AreEqual("1", doc.Dict["One"]);
+			Assert.AreEqual("2", doc.Dict["Two"]);
+		}
+
+		[Test]
+		public void GenericDictionary_string_int()
+		{
+			var results = ParseFromResource<TestDocWithGenDict2>("Resources.responseWithDict.xml");
+			Assert.AreEqual(1, results.Count);
+			var doc = results[0];
+			Assert.IsNotNull(doc.Dict);
+			Assert.AreEqual(2, doc.Dict.Count);
+			Assert.AreEqual(1, doc.Dict["One"]);
+			Assert.AreEqual(2, doc.Dict["Two"]);
+		}
+
+		[Test]
+		public void GenericDictionary_string_float()
+		{
+			var results = ParseFromResource<TestDocWithGenDict3>("Resources.responseWithDictFloat.xml");
+			Assert.AreEqual(1, results.Count);
+			var doc = results[0];
+			Assert.IsNotNull(doc.Dict);
+			Assert.AreEqual(2, doc.Dict.Count);
+			Assert.AreEqual(1.45f, doc.Dict["One"]);
+			Assert.AreEqual(2.234f, doc.Dict["Two"]);
+		}
+
+		[Test]
+		public void GenericDictionary_string_decimal()
+		{
+			var results = ParseFromResource<TestDocWithGenDict4>("Resources.responseWithDictFloat.xml");
+			Assert.AreEqual(1, results.Count);
+			var doc = results[0];
+			Assert.IsNotNull(doc.Dict);
+			Assert.AreEqual(2, doc.Dict.Count);
+			Assert.AreEqual(1.45m, doc.Dict["One"]);
+			Assert.AreEqual(2.234m, doc.Dict["Two"]);
+		}
+
+		[Test]
+		public void GenericDictionary_rest_of_fields()
+		{
+			var results = ParseFromResource<TestDocWithGenDict5>("Resources.responseWithDictFloat.xml");
+			Assert.AreEqual("1.45", results[0].DictOne);
+			Assert.IsNotNull(results[0].Dict);
+			Assert.AreEqual(4, results[0].Dict.Count);
+			Assert.AreEqual("2.234", results[0].Dict["DictTwo"]);
+			Assert.AreEqual(new DateTime(1, 1, 1), results[0].Dict["timestamp"]);
+			Assert.AreEqual(92.0f, results[0].Dict["price"]);
+			Assert.IsInstanceOfType(typeof(ICollection), results[0].Dict["features"]);
+		}
+
+		[Test]
+		public void WrongFieldDoesntThrow()
+		{
+			var results = ParseFromResource<TestDocumentWithDate>("Resources.responseWithArraysSimple.xml");
 			Assert.AreEqual(1, results.Count);
 			var doc = results[0];
 		}
 
 		[Test]
-		public void ReadsMaxScoreAttribute() {
-            var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
+		public void ReadsMaxScoreAttribute()
+		{
+			var results = ParseFromResource<TestDocumentWithArrays4>("Resources.responseWithArraysSimple.xml");
 			Assert.AreEqual(1.6578954, results.MaxScore);
 		}
 
 		[Test]
-		public void ReadMaxScore_doesnt_crash_if_not_present() {
-            var results = ParseFromResource<TestDocument>("Resources.response.xml");
+		public void ReadMaxScore_doesnt_crash_if_not_present()
+		{
+			var results = ParseFromResource<TestDocument>("Resources.response.xml");
 			Assert.IsNull(results.MaxScore);
 		}
 
-        public void ProfileTest(ProfilingContainer container) {
-            var parser = container.Resolve<ISolrAbstractResponseParser<TestDocumentWithArrays>>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArraysSimple.xml");
-            var results = new SolrQueryResults<TestDocumentWithArrays>();
+		public void ProfileTest(ProfilingContainer container)
+		{
+			var parser = container.Resolve<ISolrAbstractResponseParser<TestDocumentWithArrays>>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithArraysSimple.xml");
+			var results = new SolrQueryResults<TestDocumentWithArrays>();
 
-            for (var i = 0; i < 1000; i++) {
-                parser.Parse(xml, results);
-            }
+			for (var i = 0; i < 1000; i++)
+			{
+				parser.Parse(xml, results);
+			}
 
-            var profile = Flatten(container.GetProfile());
-            var q = from n in profile
-                    group n.Value by n.Key into x
-                    let kv = new { method = x.Key, count = x.Count(), total = x.Sum(t => t.TotalMilliseconds)}
-                    orderby kv.total descending
-                    select kv;
+			var profile = Flatten(container.GetProfile());
+			var q = from n in profile
+							group n.Value by n.Key into x
+							let kv = new { method = x.Key, count = x.Count(), total = x.Sum(t => t.TotalMilliseconds) }
+							orderby kv.total descending
+							select kv;
 
-            //foreach (var i in q)
-            //    Console.WriteLine("{0} {1}: {2} executions, {3}ms", i.method.DeclaringType, i.method, i.count, i.total);
+			//foreach (var i in q)
+			//    Console.WriteLine("{0} {1}: {2} executions, {3}ms", i.method.DeclaringType, i.method, i.count, i.total);
 
-        }
+		}
 
-        public IEnumerable<KeyValuePair<MethodInfo, TimeSpan>> Flatten(Node<KeyValuePair<MethodInfo, TimeSpan>> n) {
-            if (n.Value.Key != null)
-                yield return n.Value;
-            foreach (var i in n.Children.SelectMany(Flatten))
-                yield return i;
-        }
+		public IEnumerable<KeyValuePair<MethodInfo, TimeSpan>> Flatten(Node<KeyValuePair<MethodInfo, TimeSpan>> n)
+		{
+			if (n.Value.Key != null)
+				yield return n.Value;
+			foreach (var i in n.Children.SelectMany(Flatten))
+				yield return i;
+		}
 
 
 		[Test]
 		[Ignore("Performance test, potentially slow")]
-		public void Performance() {
-		    var container = new ProfilingContainer();
-            container.AddFacility("solr", new SolrNetFacility("http://localhost"));
-            ProfileTest(container);
+		public void Performance()
+		{
+			var container = new ProfilingContainer();
+			container.AddFacility("solr", new SolrNetFacility("http://localhost"));
+			ProfileTest(container);
 		}
 
 		[Test]
-		public void ParseFacetResults() {
-		    var parser = new FacetsResponseParser<TestDocumentWithArrays>();
-		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacet.xml");
-		    var r = new SolrQueryResults<TestDocumentWithArrays>();
-		    parser.Parse(xml, r);
+		public void ParseFacetResults()
+		{
+			var parser = new FacetsResponseParser<TestDocumentWithArrays>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacet.xml");
+			var r = new SolrQueryResults<TestDocumentWithArrays>();
+			parser.Parse(xml, r);
 			Assert.IsNotNull(r.FacetFields);
 			//Console.WriteLine(r.FacetFields.Count);
 			Assert.IsTrue(r.FacetFields.ContainsKey("cat"));
 			Assert.IsTrue(r.FacetFields.ContainsKey("inStock"));
 			Assert.AreEqual(2, r.FacetFields["cat"].First(q => q.Key == "connector").Value);
-            Assert.AreEqual(2, r.FacetFields["cat"].First(q => q.Key == "").Value); // facet.missing as empty string
+			Assert.AreEqual(2, r.FacetFields["cat"].First(q => q.Key == "").Value); // facet.missing as empty string
 
 			Assert.IsNotNull(r.FacetQueries);
 			//Console.WriteLine(r.FacetQueries.Count);
@@ -392,10 +431,11 @@ namespace SolrNet.Tests {
 		}
 
 		[Test]
-		public void ParseResponseHeader() {
-		    var parser = new HeaderResponseParser<TestDocument>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-            var docNode = xml.XPathSelectElement("response/lst[@name='responseHeader']");
+		public void ParseResponseHeader()
+		{
+			var parser = new HeaderResponseParser<TestDocument>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+			var docNode = xml.XPathSelectElement("response/lst[@name='responseHeader']");
 			var header = parser.ParseHeader(docNode);
 			Assert.AreEqual(1, header.Status);
 			Assert.AreEqual(15, header.QTime);
@@ -404,133 +444,141 @@ namespace SolrNet.Tests {
 			Assert.AreEqual("2.2", header.Params["version"]);
 		}
 
-        [Test]
-        public void ExtractResponse() {
-            var parser = new ExtractResponseParser(new HeaderResponseParser<TestDocument>());
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithExtractContent.xml");
-            var extractResponse = parser.Parse(xml);
-            Assert.AreEqual("Hello world!", extractResponse.Content);
-        }
-
-        private static IDictionary<string, HighlightedSnippets> ParseHighlightingResults(string rawXml) {
-            var xml = XDocument.Parse(rawXml);
-            var docNode = xml.XPathSelectElement("response/lst[@name='highlighting']");
-            var item = new Product { Id = "SP2514N" };
-            return HighlightingResponseParser<Product>.ParseHighlighting(new SolrQueryResults<Product> { item }, docNode);
-        }
-
-        [Test]
-        public void ParseHighlighting() {
-            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
-            Assert.AreEqual(1, highlights.Count);
-            var kv = highlights.First().Value;
-            Assert.AreEqual(1, kv.Count);
-            Assert.AreEqual("features", kv.First().Key);
-            Assert.AreEqual(1, kv.First().Value.Count);
-            //Console.WriteLine(kv.First().Value.First());
-            Assert.Like(kv.First().Value.First(), "Noise");
-        }
-
 		[Test]
-		public void ParseHighlightingWrappedWithClass() {
-		    var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
-			Assert.AreEqual(1, highlights.Count);
-		    var first = highlights.First();
-            Assert.AreEqual("SP2514N",first.Key);
-		    var fieldsWithSnippets = highlights["SP2514N"].Snippets;
-            Assert.AreEqual(1, fieldsWithSnippets.Count);
-            Assert.AreEqual("features", fieldsWithSnippets.First().Key);
-		    var snippets = highlights["SP2514N"].Snippets["features"];
-            Assert.AreEqual(1, snippets.Count);
-            Assert.Like(snippets.First(), "Noise");
+		public void ExtractResponse()
+		{
+			var parser = new ExtractResponseParser(new HeaderResponseParser<TestDocument>());
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithExtractContent.xml");
+			var extractResponse = parser.Parse(xml);
+			Assert.AreEqual("Hello world!", extractResponse.Content);
 		}
 
-        [Test]
-        public void ParseHighlighting2() {
-            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
-            var first = highlights.First();
-            //first.Value.Keys.ToList().ForEach(Console.WriteLine);
-            //first.Value["source_en"].ToList().ForEach(Console.WriteLine);
-            Assert.AreEqual(3, first.Value["source_en"].Count);
-        }
+		private static IDictionary<string, HighlightedSnippets> ParseHighlightingResults(string rawXml)
+		{
+			var xml = XDocument.Parse(rawXml);
+			var docNode = xml.XPathSelectElement("response/lst[@name='highlighting']");
+			var item = new Product { Id = "SP2514N" };
+			return HighlightingResponseParser<Product>.ParseHighlighting(new SolrQueryResults<Product> { item }, docNode);
+		}
 
-        [Test]
-        public void ParseHighlighting2WrappedWithClass()
-        {
-            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
-            var first = highlights.First();
-            //foreach (var i in first.Value.Snippets.Keys)
-            //    Console.WriteLine(i);
-            //foreach (var i in first.Value.Snippets["source_en"])
-            //    Console.WriteLine(i);
-            Assert.AreEqual(3, first.Value.Snippets["source_en"].Count);
-        }
+		[Test]
+		public void ParseHighlighting()
+		{
+			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
+			Assert.AreEqual(1, highlights.Count);
+			var kv = highlights.First().Value;
+			Assert.AreEqual(1, kv.Count);
+			Assert.AreEqual("features", kv.First().Key);
+			Assert.AreEqual(1, kv.First().Value.Count);
+			//Console.WriteLine(kv.First().Value.First());
+			Assert.Like(kv.First().Value.First(), "Noise");
+		}
 
-        [Test]
-        public void ParseHighlighting3() {
-            var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting3.xml"));
-            Assert.AreEqual(0, highlights["e4420cc2"].Count);
-            Assert.AreEqual(1, highlights["e442c4cd"].Count);
-            Assert.AreEqual(1, highlights["e442c4cd"]["bodytext"].Count);
-            Assert.Contains(highlights["e442c4cd"]["bodytext"].First(), "Garia lancerer");
-        }
-        
-        [Test]
-        public void ParseSpellChecking() {
-            var parser = new SpellCheckResponseParser<Product>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking.xml");
-            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
-            var spellChecking = parser.ParseSpellChecking(docNode);
-            Assert.IsNotNull(spellChecking);
-            Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
-            Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
-            Assert.AreEqual(2, spellChecking.Collations.Count);
-        }
+		[Test]
+		public void ParseHighlightingWrappedWithClass()
+		{
+			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting.xml"));
+			Assert.AreEqual(1, highlights.Count);
+			var first = highlights.First();
+			Assert.AreEqual("SP2514N", first.Key);
+			var fieldsWithSnippets = highlights["SP2514N"].Snippets;
+			Assert.AreEqual(1, fieldsWithSnippets.Count);
+			Assert.AreEqual("features", fieldsWithSnippets.First().Key);
+			var snippets = highlights["SP2514N"].Snippets["features"];
+			Assert.AreEqual(1, snippets.Count);
+			Assert.Like(snippets.First(), "Noise");
+		}
 
-        [Test]
-        public void ParseSpellChecking2()
-        {
-            var parser = new SpellCheckResponseParser<Product>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking2.xml");
-            var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
-            var spellChecking = parser.ParseSpellChecking(docNode);
-            Assert.IsNotNull(spellChecking);
-            Assert.AreEqual(2, spellChecking.Count);
-            Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
-            Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
-            Assert.AreEqual(2, spellChecking.Collations.Count);
-         }
+		[Test]
+		public void ParseHighlighting2()
+		{
+			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
+			var first = highlights.First();
+			//first.Value.Keys.ToList().ForEach(Console.WriteLine);
+			//first.Value["source_en"].ToList().ForEach(Console.WriteLine);
+			Assert.AreEqual(3, first.Value["source_en"].Count);
+		}
 
-        [Test]
-        public void ParseClustering() {
-            var parser = new ClusterResponseParser<Product>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithClustering.xml");
-            var docNode = xml.XPathSelectElement("response/arr[@name='clusters']");
-            var clustering = parser.ParseClusterNode(docNode);
-            Assert.IsNotNull(clustering);
-            Assert.AreEqual(89, clustering.Clusters.Count());
-            Assert.AreEqual("International", clustering.Clusters.First().Label);
-            Assert.AreEqual(33.729704170097, clustering.Clusters.First().Score);
-            Assert.AreEqual(8, clustering.Clusters.First().Documents.Count());
-            Assert.AreEqual("19622040", clustering.Clusters.First().Documents.First());
-        }
+		[Test]
+		public void ParseHighlighting2WrappedWithClass()
+		{
+			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting2.xml"));
+			var first = highlights.First();
+			//foreach (var i in first.Value.Snippets.Keys)
+			//    Console.WriteLine(i);
+			//foreach (var i in first.Value.Snippets["source_en"])
+			//    Console.WriteLine(i);
+			Assert.AreEqual(3, first.Value.Snippets["source_en"].Count);
+		}
 
-        [Test]
-        public void ParseTerms()
-        {
-            var parser = new TermsResponseParser<Product>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTerms.xml");
-            var docNode = xml.XPathSelectElement("response/lst[@name='terms']");
-            var terms = parser.ParseTerms(docNode);
-            Assert.IsNotNull(terms);
-            Assert.AreEqual(2, terms.Count);
-            Assert.AreEqual("text", terms.First().Field);
-            Assert.AreEqual("textgen", terms.ElementAt(1).Field);
-            Assert.AreEqual("boot", terms.First().Terms.First().Key);
-            Assert.AreEqual(479, terms.First().Terms.First().Value);
-            Assert.AreEqual("boots", terms.ElementAt(1).Terms.First().Key);
-            Assert.AreEqual(463, terms.ElementAt(1).Terms.First().Value);
-        }
+		[Test]
+		public void ParseHighlighting3()
+		{
+			var highlights = ParseHighlightingResults(EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithHighlighting3.xml"));
+			Assert.AreEqual(0, highlights["e4420cc2"].Count);
+			Assert.AreEqual(1, highlights["e442c4cd"].Count);
+			Assert.AreEqual(1, highlights["e442c4cd"]["bodytext"].Count);
+			Assert.Contains(highlights["e442c4cd"]["bodytext"].First(), "Garia lancerer");
+		}
+
+		[Test]
+		public void ParseSpellChecking()
+		{
+			var parser = new SpellCheckResponseParser<Product>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking.xml");
+			var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+			var spellChecking = parser.ParseSpellChecking(docNode);
+			Assert.IsNotNull(spellChecking);
+			Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
+			Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
+			Assert.AreEqual(2, spellChecking.Collations.Count);
+		}
+
+		[Test]
+		public void ParseSpellChecking2()
+		{
+			var parser = new SpellCheckResponseParser<Product>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithSpellChecking2.xml");
+			var docNode = xml.XPathSelectElement("response/lst[@name='spellcheck']");
+			var spellChecking = parser.ParseSpellChecking(docNode);
+			Assert.IsNotNull(spellChecking);
+			Assert.AreEqual(2, spellChecking.Count);
+			Assert.AreEqual("dell ultrasharp", spellChecking.Collations.ElementAt(0));
+			Assert.AreEqual("dell ultrasharps", spellChecking.Collations.ElementAt(1));
+			Assert.AreEqual(2, spellChecking.Collations.Count);
+		}
+
+		[Test]
+		public void ParseClustering()
+		{
+			var parser = new ClusterResponseParser<Product>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithClustering.xml");
+			var docNode = xml.XPathSelectElement("response/arr[@name='clusters']");
+			var clustering = parser.ParseClusterNode(docNode);
+			Assert.IsNotNull(clustering);
+			Assert.AreEqual(89, clustering.Clusters.Count());
+			Assert.AreEqual("International", clustering.Clusters.First().Label);
+			Assert.AreEqual(33.729704170097, clustering.Clusters.First().Score);
+			Assert.AreEqual(8, clustering.Clusters.First().Documents.Count());
+			Assert.AreEqual("19622040", clustering.Clusters.First().Documents.First());
+		}
+
+		[Test]
+		public void ParseTerms()
+		{
+			var parser = new TermsResponseParser<Product>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTerms.xml");
+			var docNode = xml.XPathSelectElement("response/lst[@name='terms']");
+			var terms = parser.ParseTerms(docNode);
+			Assert.IsNotNull(terms);
+			Assert.AreEqual(2, terms.Count);
+			Assert.AreEqual("text", terms.First().Field);
+			Assert.AreEqual("textgen", terms.ElementAt(1).Field);
+			Assert.AreEqual("boot", terms.First().Terms.First().Key);
+			Assert.AreEqual(479, terms.First().Terms.First().Value);
+			Assert.AreEqual("boots", terms.ElementAt(1).Terms.First().Key);
+			Assert.AreEqual(463, terms.ElementAt(1).Terms.First().Value);
+		}
 
 		[Test]
 		public void ParseTermVector()
@@ -542,176 +590,183 @@ namespace SolrNet.Tests {
 
 			Assert.IsNotNull(docs);
 			Assert.AreEqual(2, docs.Count);
-            var cable = docs
-                .First(d => d.UniqueKey == "3007WFP")
-                .TermVector
-                .First(f => f.Field == "includes");
+			var cable = docs
+					.First(d => d.UniqueKey == "3007WFP")
+					.TermVector
+					.First(f => f.Field == "includes");
 
-            Assert.AreEqual("cable", cable.Term);
-            Assert.AreEqual(1, cable.Tf);
-            Assert.AreEqual(1, cable.Df);
+			Assert.AreEqual("cable", cable.Term);
+			Assert.AreEqual(1, cable.Tf);
+			Assert.AreEqual(1, cable.Df);
 			Assert.AreEqual(1.0, cable.Tf_Idf);
 
-		    var positions = cable.Positions.ToList();
-            Assert.AreEqual(2, cable.Positions.Count);
-            Assert.AreEqual(1, positions[0]);
-            Assert.AreEqual(10, positions[1]);
+			var positions = cable.Positions.ToList();
+			Assert.AreEqual(2, cable.Positions.Count);
+			Assert.AreEqual(1, positions[0]);
+			Assert.AreEqual(10, positions[1]);
 
-		    var offsets = cable.Offsets.ToList();
-            Assert.AreEqual(1, cable.Offsets.Count);
-            Assert.AreEqual(4, offsets[0].Start);
-            Assert.AreEqual(9, offsets[0].End);
+			var offsets = cable.Offsets.ToList();
+			Assert.AreEqual(1, cable.Offsets.Count);
+			Assert.AreEqual(4, offsets[0].Start);
+			Assert.AreEqual(9, offsets[0].End);
 		}
 
-        [Test]
-        public void ParseTermVector2() {
-            var parser = new TermVectorResultsParser<Product>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTermVector2.xml");
-            var docNode = xml.XPathSelectElement("response/lst[@name='termVectors']");
-            var docs = parser.ParseDocuments(docNode).ToList();
-            Assert.IsNotNull(docs);
-            Assert.AreEqual(1, docs.Count);
-            Assert.AreEqual("20", docs[0].UniqueKey);
-            var vectors = docs[0].TermVector.ToList();
-            Assert.AreEqual(15, vectors.Count);
-        }
-
-        [Test]
-        public void ParseMoreLikeThis() {
-            var mapper = new AttributesMappingManager();
-            var parser = new MoreLikeThisResponseParser<Product>(new SolrDocumentResponseParser<Product>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Product>()));
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMoreLikeThis.xml");
-            var docNode = xml.XPathSelectElement("response/lst[@name='moreLikeThis']");
-            var product1 = new Product { Id = "UTF8TEST" };
-            var product2 = new Product { Id = "SOLR1000" };
-            var mlt = parser.ParseMoreLikeThis(new[] {
-                product1,
-                product2,
-            }, docNode);
-            Assert.IsNotNull(mlt);
-            Assert.AreEqual(2, mlt.Count);
-            Assert.IsTrue(mlt.ContainsKey(product1.Id));
-            Assert.IsTrue(mlt.ContainsKey(product2.Id));
-            Assert.AreEqual(1, mlt[product1.Id].Count);
-            Assert.AreEqual(1, mlt[product2.Id].Count);
-            //Console.WriteLine(mlt[product1.Id][0].Id);
-        }
-
-        [Test]
-        public void ParseStatsResults() {
-            var parser = new StatsResponseParser<Product>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithStats.xml");
-            var docNode = xml.XPathSelectElement("response/lst[@name='stats']");
-            var stats = parser.ParseStats(docNode, "stats_fields");
-            Assert.AreEqual(2, stats.Count);
-            Assert.IsTrue(stats.ContainsKey("price"));
-            var priceStats = stats["price"];
-            Assert.AreEqual(0.0, priceStats.Min);
-            Assert.AreEqual(2199.0, priceStats.Max);
-            Assert.AreEqual(5251.2699999999995, priceStats.Sum);
-            Assert.AreEqual(15, priceStats.Count);
-            Assert.AreEqual(11, priceStats.Missing);
-            Assert.AreEqual(6038619.160300001, priceStats.SumOfSquares);
-            Assert.AreEqual(350.08466666666664, priceStats.Mean);
-            Assert.AreEqual(547.737557906113, priceStats.StdDev);
-            Assert.AreEqual(1, priceStats.FacetResults.Count);
-            Assert.IsTrue(priceStats.FacetResults.ContainsKey("inStock"));
-            var priceInStockStats = priceStats.FacetResults["inStock"];
-            Assert.AreEqual(2, priceInStockStats.Count);
-            Assert.IsTrue(priceInStockStats.ContainsKey("true"));
-            Assert.IsTrue(priceInStockStats.ContainsKey("false"));
-            var priceInStockFalseStats = priceInStockStats["false"];
-            Assert.AreEqual(11.5, priceInStockFalseStats.Min);
-            Assert.AreEqual(649.99, priceInStockFalseStats.Max);
-            Assert.AreEqual(1161.39, priceInStockFalseStats.Sum);
-            Assert.AreEqual(4, priceInStockFalseStats.Count);
-            Assert.AreEqual(0, priceInStockFalseStats.Missing);
-            Assert.AreEqual(653369.2551, priceInStockFalseStats.SumOfSquares);
-            Assert.AreEqual(290.3475, priceInStockFalseStats.Mean);
-            Assert.AreEqual(324.63444676281654, priceInStockFalseStats.StdDev);
-            var priceInStockTrueStats = priceInStockStats["true"];
-            Assert.AreEqual(0.0, priceInStockTrueStats.Min);
-            Assert.AreEqual(2199.0, priceInStockTrueStats.Max);
-            Assert.AreEqual(4089.879999999999, priceInStockTrueStats.Sum);
-            Assert.AreEqual(11, priceInStockTrueStats.Count);
-            Assert.AreEqual(0, priceInStockTrueStats.Missing);
-            Assert.AreEqual(5385249.905200001, priceInStockTrueStats.SumOfSquares);
-            Assert.AreEqual(371.8072727272727, priceInStockTrueStats.Mean);
-            Assert.AreEqual(621.6592938755265, priceInStockTrueStats.StdDev);
-
-            var zeroResultsStats = stats["zeroResults"];
-            Assert.AreEqual(double.NaN, zeroResultsStats.Min);
-            Assert.AreEqual(double.NaN, zeroResultsStats.Max);
-            Assert.AreEqual(0, zeroResultsStats.Count);
-            Assert.AreEqual(0, zeroResultsStats.Missing);
-            Assert.AreEqual(0.0, zeroResultsStats.Sum);
-            Assert.AreEqual(0.0, zeroResultsStats.SumOfSquares);
-            Assert.AreEqual(double.NaN, zeroResultsStats.Mean);
-            Assert.AreEqual(0.0, zeroResultsStats.StdDev);
-        }
-
-        [Test]
-        public void ParseStatsResults2() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithStats.xml");
-            var parser = new StatsResponseParser<Product>();
-            var stats = parser.ParseStats(xml.Root, "stats_fields");
-
-            Assert.IsNotNull(stats);
-            Assert.Contains(stats.Keys, "instock_prices");
-            Assert.Contains(stats.Keys, "all_prices");
-
-            var instock = stats["instock_prices"];
-            Assert.AreEqual(0, instock.Min);
-            Assert.AreEqual(2199, instock.Max);
-            Assert.AreEqual(16, instock.Count);
-            Assert.AreEqual(16, instock.Missing);
-            Assert.AreEqual(5251.270030975342, instock.Sum);
-
-            var all = stats["all_prices"];
-            Assert.AreEqual(4089.880027770996, all.Sum);
-            Assert.AreEqual(2199, all.Max);
-        }
-
-        [Test]
-        public void ParseFacetDateResults() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacet.xml");
-            var p = new FacetsResponseParser<Product>();
-            var results = p.ParseFacetDates(xml.Root);
-            Assert.AreEqual(1, results.Count);
-            var result = results.First();
-            Assert.AreEqual("timestamp", result.Key);
-            Assert.AreEqual("+1DAY", result.Value.Gap);
-            Assert.AreEqual(new DateTime(2009, 8, 10, 0, 33, 46, 578), result.Value.End);
-            var dateResults = result.Value.DateResults;
-            Assert.AreEqual(1, dateResults.Count);
-            Assert.AreEqual(16, dateResults[0].Value);
-            Assert.AreEqual(new DateTime(2009, 8, 9, 0, 33, 46, 578), dateResults[0].Key);
-        }
-
-        [Test]
-        public void ParseFacetDateResultsWithOther() {
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacetAndOther.xml");
-            var p = new FacetsResponseParser<Product>();
-            var results = p.ParseFacetDates(xml.Root);
-            Assert.AreEqual(1, results.Count);
-            var result = results.First();
-            Assert.AreEqual("timestamp", result.Key);
-            Assert.AreEqual("+1DAY", result.Value.Gap);
-            Assert.AreEqual(new DateTime(2009, 8, 10, 0, 46, 29), result.Value.End);
-            Assert.AreEqual(new DateTime(2009, 8, 9, 22, 46, 29), result.Value.DateResults[0].Key);
-            var other = result.Value.OtherResults;
-            Assert.AreEqual(1, other[FacetDateOther.Before]);
-            Assert.AreEqual(0, other[FacetDateOther.After]);
-            Assert.AreEqual(0, other[FacetDateOther.Between]);
-        }
+		[Test]
+		public void ParseTermVector2()
+		{
+			var parser = new TermVectorResultsParser<Product>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithTermVector2.xml");
+			var docNode = xml.XPathSelectElement("response/lst[@name='termVectors']");
+			var docs = parser.ParseDocuments(docNode).ToList();
+			Assert.IsNotNull(docs);
+			Assert.AreEqual(1, docs.Count);
+			Assert.AreEqual("20", docs[0].UniqueKey);
+			var vectors = docs[0].TermVector.ToList();
+			Assert.AreEqual(15, vectors.Count);
+		}
 
 		[Test]
-		public void ParseResultsWithGroups() {
+		public void ParseMoreLikeThis()
+		{
+			var mapper = new AttributesMappingManager();
+			var parser = new MoreLikeThisResponseParser<Product>(new SolrDocumentResponseParser<Product>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Product>()));
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithMoreLikeThis.xml");
+			var docNode = xml.XPathSelectElement("response/lst[@name='moreLikeThis']");
+			var product1 = new Product { Id = "UTF8TEST" };
+			var product2 = new Product { Id = "SOLR1000" };
+			var mlt = parser.ParseMoreLikeThis(new[] {
+								product1,
+								product2,
+						}, docNode);
+			Assert.IsNotNull(mlt);
+			Assert.AreEqual(2, mlt.Count);
+			Assert.IsTrue(mlt.ContainsKey(product1.Id));
+			Assert.IsTrue(mlt.ContainsKey(product2.Id));
+			Assert.AreEqual(1, mlt[product1.Id].Count);
+			Assert.AreEqual(1, mlt[product2.Id].Count);
+			//Console.WriteLine(mlt[product1.Id][0].Id);
+		}
+
+		[Test]
+		public void ParseStatsResults()
+		{
+			var parser = new StatsResponseParser<Product>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithStats.xml");
+			var docNode = xml.XPathSelectElement("response/lst[@name='stats']");
+			var stats = parser.ParseStats(docNode, "stats_fields");
+			Assert.AreEqual(2, stats.Count);
+			Assert.IsTrue(stats.ContainsKey("price"));
+			var priceStats = stats["price"];
+			Assert.AreEqual(0.0, priceStats.Min);
+			Assert.AreEqual(2199.0, priceStats.Max);
+			Assert.AreEqual(5251.2699999999995, priceStats.Sum);
+			Assert.AreEqual(15, priceStats.Count);
+			Assert.AreEqual(11, priceStats.Missing);
+			Assert.AreEqual(6038619.160300001, priceStats.SumOfSquares);
+			Assert.AreEqual(350.08466666666664, priceStats.Mean);
+			Assert.AreEqual(547.737557906113, priceStats.StdDev);
+			Assert.AreEqual(1, priceStats.FacetResults.Count);
+			Assert.IsTrue(priceStats.FacetResults.ContainsKey("inStock"));
+			var priceInStockStats = priceStats.FacetResults["inStock"];
+			Assert.AreEqual(2, priceInStockStats.Count);
+			Assert.IsTrue(priceInStockStats.ContainsKey("true"));
+			Assert.IsTrue(priceInStockStats.ContainsKey("false"));
+			var priceInStockFalseStats = priceInStockStats["false"];
+			Assert.AreEqual(11.5, priceInStockFalseStats.Min);
+			Assert.AreEqual(649.99, priceInStockFalseStats.Max);
+			Assert.AreEqual(1161.39, priceInStockFalseStats.Sum);
+			Assert.AreEqual(4, priceInStockFalseStats.Count);
+			Assert.AreEqual(0, priceInStockFalseStats.Missing);
+			Assert.AreEqual(653369.2551, priceInStockFalseStats.SumOfSquares);
+			Assert.AreEqual(290.3475, priceInStockFalseStats.Mean);
+			Assert.AreEqual(324.63444676281654, priceInStockFalseStats.StdDev);
+			var priceInStockTrueStats = priceInStockStats["true"];
+			Assert.AreEqual(0.0, priceInStockTrueStats.Min);
+			Assert.AreEqual(2199.0, priceInStockTrueStats.Max);
+			Assert.AreEqual(4089.879999999999, priceInStockTrueStats.Sum);
+			Assert.AreEqual(11, priceInStockTrueStats.Count);
+			Assert.AreEqual(0, priceInStockTrueStats.Missing);
+			Assert.AreEqual(5385249.905200001, priceInStockTrueStats.SumOfSquares);
+			Assert.AreEqual(371.8072727272727, priceInStockTrueStats.Mean);
+			Assert.AreEqual(621.6592938755265, priceInStockTrueStats.StdDev);
+
+			var zeroResultsStats = stats["zeroResults"];
+			Assert.AreEqual(double.NaN, zeroResultsStats.Min);
+			Assert.AreEqual(double.NaN, zeroResultsStats.Max);
+			Assert.AreEqual(0, zeroResultsStats.Count);
+			Assert.AreEqual(0, zeroResultsStats.Missing);
+			Assert.AreEqual(0.0, zeroResultsStats.Sum);
+			Assert.AreEqual(0.0, zeroResultsStats.SumOfSquares);
+			Assert.AreEqual(double.NaN, zeroResultsStats.Mean);
+			Assert.AreEqual(0.0, zeroResultsStats.StdDev);
+		}
+
+		[Test]
+		public void ParseStatsResults2()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithStats.xml");
+			var parser = new StatsResponseParser<Product>();
+			var stats = parser.ParseStats(xml.Root, "stats_fields");
+
+			Assert.IsNotNull(stats);
+			Assert.Contains(stats.Keys, "instock_prices");
+			Assert.Contains(stats.Keys, "all_prices");
+
+			var instock = stats["instock_prices"];
+			Assert.AreEqual(0, instock.Min);
+			Assert.AreEqual(2199, instock.Max);
+			Assert.AreEqual(16, instock.Count);
+			Assert.AreEqual(16, instock.Missing);
+			Assert.AreEqual(5251.270030975342, instock.Sum);
+
+			var all = stats["all_prices"];
+			Assert.AreEqual(4089.880027770996, all.Sum);
+			Assert.AreEqual(2199, all.Max);
+		}
+
+		[Test]
+		public void ParseFacetDateResults()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacet.xml");
+			var p = new FacetsResponseParser<Product>();
+			var results = p.ParseFacetDates(xml.Root);
+			Assert.AreEqual(1, results.Count);
+			var result = results.First();
+			Assert.AreEqual("timestamp", result.Key);
+			Assert.AreEqual("+1DAY", result.Value.Gap);
+			Assert.AreEqual(new DateTime(2009, 8, 10, 0, 33, 46, 578), result.Value.End);
+			var dateResults = result.Value.DateResults;
+			Assert.AreEqual(1, dateResults.Count);
+			Assert.AreEqual(16, dateResults[0].Value);
+			Assert.AreEqual(new DateTime(2009, 8, 9, 0, 33, 46, 578), dateResults[0].Key);
+		}
+
+		[Test]
+		public void ParseFacetDateResultsWithOther()
+		{
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.partialResponseWithDateFacetAndOther.xml");
+			var p = new FacetsResponseParser<Product>();
+			var results = p.ParseFacetDates(xml.Root);
+			Assert.AreEqual(1, results.Count);
+			var result = results.First();
+			Assert.AreEqual("timestamp", result.Key);
+			Assert.AreEqual("+1DAY", result.Value.Gap);
+			Assert.AreEqual(new DateTime(2009, 8, 10, 0, 46, 29), result.Value.End);
+			Assert.AreEqual(new DateTime(2009, 8, 9, 22, 46, 29), result.Value.DateResults[0].Key);
+			var other = result.Value.OtherResults;
+			Assert.AreEqual(1, other[FacetDateOther.Before]);
+			Assert.AreEqual(0, other[FacetDateOther.After]);
+			Assert.AreEqual(0, other[FacetDateOther.Between]);
+		}
+
+		[Test]
+		public void ParseResultsWithGroups()
+		{
 			var mapper = new AttributesMappingManager();
 			var parser = new GroupingResponseParser<Product>(new SolrDocumentResponseParser<Product>(mapper, new DefaultDocumentVisitor(mapper, new DefaultFieldParser()), new SolrDocumentActivator<Product>()));
-		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithGroupingOnInstock.xml");
-		    var results = new SolrQueryResults<Product>();
-		    parser.Parse(xml, results);
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithGroupingOnInstock.xml");
+			var results = new SolrQueryResults<Product>();
+			parser.Parse(xml, results);
 			Assert.AreEqual(1, results.Grouping.Count);
 			Assert.AreEqual(2, results.Grouping["inStock"].Groups.Count());
 			Assert.AreEqual(13, results.Grouping["inStock"].Groups.First().NumFound);
@@ -721,88 +776,92 @@ namespace SolrNet.Tests {
 		public void ParseResultsWithFacetPivot()
 		{
 			var parser = new FacetsResponseParser<Product>();
-		    var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacetPivoting.xml");
-		    var r = new SolrQueryResults<Product>();
-		    parser.Parse(xml, r);
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithFacetPivoting.xml");
+			var r = new SolrQueryResults<Product>();
+			parser.Parse(xml, r);
 			Assert.IsNotNull(r.FacetPivots);
 			//Console.WriteLine(r.FacetPivots.Count);
 			Assert.IsTrue(r.FacetPivots.ContainsKey("inStock,manu"));
 
 			Assert.AreEqual(2, r.FacetPivots["inStock,manu"].Count);
 			Assert.AreEqual("inStock", r.FacetPivots["inStock,manu"][0].Field);
-			Assert.AreEqual(10, r.FacetPivots["inStock,manu"][0].ChildPivots.Count); 
+			Assert.AreEqual(10, r.FacetPivots["inStock,manu"][0].ChildPivots.Count);
 
-		} 
+		}
 
-        [Test]
-        public void PropertyWithoutSetter() {
-            var parser = GetDocumentParser<TestDocWithoutSetter>();
-            var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
-            var docNode = xml.XPathSelectElement("response/result/doc");
-            var doc = parser.ParseDocument(docNode);
-            Assert.IsNotNull(doc);
-            Assert.AreEqual(0, doc.Id);
-        }
+		[Test]
+		public void PropertyWithoutSetter()
+		{
+			var parser = GetDocumentParser<TestDocWithoutSetter>();
+			var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.response.xml");
+			var docNode = xml.XPathSelectElement("response/result/doc");
+			var docs = parser.ParseDocument(docNode).ToList();
+			Assert.IsTrue(docs.Count > 0);
+			Assert.AreEqual(0, docs[0].Id);
+		}
 
-        [Test]
-        public void ParseInterestingTermsList()
-        {
-            var innerParser = new InterestingTermsResponseParser<Product>();
-            var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
-            var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsList.xml");
-            var results = parser.Parse(response);
+		[Test]
+		public void ParseInterestingTermsList()
+		{
+			var innerParser = new InterestingTermsResponseParser<Product>();
+			var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
+			var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsList.xml");
+			var results = parser.Parse(response);
 
-            Assert.IsNotNull(results);
-            Assert.IsNotNull(results.InterestingTerms);
-            Assert.AreEqual(4, results.InterestingTerms.Count);
-            Assert.AreEqual("three", results.InterestingTerms[2].Key);
-            Assert.IsTrue(results.InterestingTerms.All(t => t.Value == 0.0f));
-        }
+			Assert.IsNotNull(results);
+			Assert.IsNotNull(results.InterestingTerms);
+			Assert.AreEqual(4, results.InterestingTerms.Count);
+			Assert.AreEqual("three", results.InterestingTerms[2].Key);
+			Assert.IsTrue(results.InterestingTerms.All(t => t.Value == 0.0f));
+		}
 
-        [Test]
-        public void ParseInterestingTermsDetails()
-        {
-            var innerParser = new InterestingTermsResponseParser<Product>();
-            var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
-            var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
-            var results = parser.Parse(response);
+		[Test]
+		public void ParseInterestingTermsDetails()
+		{
+			var innerParser = new InterestingTermsResponseParser<Product>();
+			var parser = new SolrMoreLikeThisHandlerQueryResultsParser<Product>(new[] { innerParser });
+			var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
+			var results = parser.Parse(response);
 
-            Assert.IsNotNull(results);
-            Assert.IsNotNull(results.InterestingTerms);
-            Assert.AreEqual(4, results.InterestingTerms.Count);
-            Assert.AreEqual("content:three", results.InterestingTerms[2].Key);
-            Assert.AreEqual(3.3f, results.InterestingTerms[2].Value);
-        }
+			Assert.IsNotNull(results);
+			Assert.IsNotNull(results.InterestingTerms);
+			Assert.AreEqual(4, results.InterestingTerms.Count);
+			Assert.AreEqual("content:three", results.InterestingTerms[2].Key);
+			Assert.AreEqual(3.3f, results.InterestingTerms[2].Value);
+		}
 
-        [Test]
-        public void ParseMlthMatch()
-        {
-            var innerParser = new MoreLikeThisHandlerMatchResponseParser<TestDocWithGuid>(GetDocumentParser<TestDocWithGuid>());
-            var parser = new SolrMoreLikeThisHandlerQueryResultsParser<TestDocWithGuid>(new[] { innerParser });
-            var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
-            var results = parser.Parse(response);
+		[Test]
+		public void ParseMlthMatch()
+		{
+			var innerParser = new MoreLikeThisHandlerMatchResponseParser<TestDocWithGuid>(GetDocumentParser<TestDocWithGuid>());
+			var parser = new SolrMoreLikeThisHandlerQueryResultsParser<TestDocWithGuid>(new[] { innerParser });
+			var response = EmbeddedResource.GetEmbeddedString(GetType(), "Resources.responseWithInterestingTermsDetails.xml");
+			var results = parser.Parse(response);
 
-            Assert.IsNotNull(results);
-            Assert.IsNotNull(results.Match);
-            Assert.AreEqual(new Guid("224fbdc1-12df-4520-9fbe-dd91f916eba1"), results.Match.Key);
-        }
+			Assert.IsNotNull(results);
+			Assert.IsNotNull(results.Match);
+			Assert.AreEqual(new Guid("224fbdc1-12df-4520-9fbe-dd91f916eba1"), results.Match.Key);
+		}
 
-        public enum AEnum {
-            One,
-            Two,
-            Three
-        }
+		public enum AEnum
+		{
+			One,
+			Two,
+			Three
+		}
 
-        
 
-        public class TestDocWithEnum {
-            [SolrField]
-            public AEnum En { get; set; }
-        }
 
-        public class TestDocWithNullableEnum {
-            [SolrField("basicview")]
-            public AEnum? BasicView { get; set; }
-        }
+		public class TestDocWithEnum
+		{
+			[SolrField]
+			public AEnum En { get; set; }
+		}
+
+		public class TestDocWithNullableEnum
+		{
+			[SolrField("basicview")]
+			public AEnum? BasicView { get; set; }
+		}
 	}
 }

--- a/SolrNet.Tests/SolrQueryResultsParserTestsDocumentClasses.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTestsDocumentClasses.cs
@@ -73,7 +73,24 @@ namespace SolrNet.Tests {
             public int Id { get; set; }
         }
 
-        public class TestDocumentWithoutAttributes {
+			public class TestDocumentWithChildren {
+				[SolrField("advancedview")]
+				public string AdvancedView { get; set; }
+
+				[SolrField("basicview")]
+				public string BasicView { get; set; }
+
+				[SolrField("id")]
+				public int Id { get; set; }
+
+				[SolrField("childField")]
+				public string ChildField { get; set; }
+
+				[SolrField("sameFieldName")]
+				public string SameFieldName { get; set; }
+			}
+
+      public class TestDocumentWithoutAttributes {
             public int Id { get; set; }
         }
 

--- a/SolrNet/Impl/SolrDocumentResponseParser.cs
+++ b/SolrNet/Impl/SolrDocumentResponseParser.cs
@@ -17,51 +17,88 @@
 using System.Collections.Generic;
 using System.Xml.Linq;
 
-namespace SolrNet.Impl {
-    /// <summary>
-    /// Parses documents from query response
-    /// </summary>
-    /// <typeparam name="T">Document type</typeparam>
-    public class SolrDocumentResponseParser<T> : ISolrDocumentResponseParser<T> {
-        private readonly IReadOnlyMappingManager mappingManager;
-        private readonly ISolrDocumentPropertyVisitor propVisitor;
-        private readonly ISolrDocumentActivator<T> activator;
+namespace SolrNet.Impl
+{
+	/// <summary>
+	/// Parses documents from query response
+	/// </summary>
+	/// <typeparam name="T">Document type</typeparam>
+	public class SolrDocumentResponseParser<T> : ISolrDocumentResponseParser<T>
+	{
+		private readonly IReadOnlyMappingManager mappingManager;
+		private readonly ISolrDocumentPropertyVisitor propVisitor;
+		private readonly ISolrDocumentActivator<T> activator;
 
-        public SolrDocumentResponseParser(IReadOnlyMappingManager mappingManager, ISolrDocumentPropertyVisitor propVisitor, ISolrDocumentActivator<T> activator) {
-            this.mappingManager = mappingManager;
-            this.propVisitor = propVisitor;
-            this.activator = activator;
-        }
+		public SolrDocumentResponseParser(IReadOnlyMappingManager mappingManager, ISolrDocumentPropertyVisitor propVisitor, ISolrDocumentActivator<T> activator)
+		{
+			this.mappingManager = mappingManager;
+			this.propVisitor = propVisitor;
+			this.activator = activator;
+		}
 
-        /// <summary>
-        /// Parses documents results
-        /// </summary>
-        /// <param name="parentNode"></param>
-        /// <returns></returns>
-        public IList<T> ParseResults(XElement parentNode) {
-            var results = new List<T>();
-            if (parentNode == null)
-                return results;
-            var nodes = parentNode.Elements("doc");
-            foreach (var docNode in nodes) {
-                results.Add(ParseDocument(docNode));
-            }
-            return results;
-        }
+		/// <summary>
+		/// Parses documents results
+		/// </summary>
+		/// <param name="parentNode"></param>
+		/// <returns></returns>
+		public IList<T> ParseResults(XElement parentNode)
+		{
+			var results = new List<T>();
+			if (parentNode == null)
+				return results;
+			var nodes = parentNode.Elements("doc");
+			foreach (var docNode in nodes)
+			{
+				results.AddRange(ParseDocument(docNode));
+			}
+			return results;
+		}
 
-        /// <summary>
-        /// Builds a document from the corresponding response xml node
-        /// </summary>
-        /// <param name="node">response xml node</param>
-        /// <param name="fields">document fields</param>
-        /// <returns>populated document</returns>
-        public T ParseDocument(XElement node) {
-            var doc = activator.Create();
-            foreach (var field in node.Elements()) {
-                string fieldName = field.Attribute("name").Value;
-                propVisitor.Visit(doc, fieldName, field);
-            }
-            return doc;
-        }
-    }
+		/// <summary>
+		/// Builds a document from the corresponding response xml node
+		/// </summary>
+		/// <param name="node">response xml node</param>
+		/// <param name="fields">document fields</param>
+		/// <returns>populated document(s)</returns>
+		public IEnumerable<T> ParseDocument(XElement node)
+		{
+			IList<T> docs = new List<T>();
+			IList<XElement> children = new List<XElement>();
+
+			var doc = activator.Create();
+
+			foreach (var field in node.Elements())
+			{
+				if (field.HasElements &&
+							 string.Equals(field.Name.LocalName, "doc", System.StringComparison.OrdinalIgnoreCase))
+				{
+					children.Add(field);
+				}
+				else
+				{
+					string fieldName = field.Attribute("name").Value;
+					propVisitor.Visit(doc, fieldName, field);
+				}
+			}
+
+			if (children.Count > 0)
+			{
+				foreach (var child in children)
+				{
+					foreach (var field in child.Elements())
+					{
+						string fieldName = field.Attribute("name").Value;
+						propVisitor.Visit(doc, fieldName, field);
+					}
+					docs.Add(doc);
+				}
+			}
+			else
+			{
+				docs.Add(doc);
+			}
+
+			return docs;
+		}
+	}
 }

--- a/SolrNet/Impl/SolrDocumentResponseParser.cs
+++ b/SolrNet/Impl/SolrDocumentResponseParser.cs
@@ -14,8 +14,10 @@
 // limitations under the License.
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
+using SolrNet.Utils;
 
 namespace SolrNet.Impl
 {
@@ -81,16 +83,16 @@ namespace SolrNet.Impl
 				}
 			}
 
-			if (children.Count > 0)
-			{
+			if (children.Count > 0) {
 				foreach (var child in children)
 				{
+					var newDoc = ShallowClone.Clone(doc);
 					foreach (var field in child.Elements())
 					{
 						string fieldName = field.Attribute("name").Value;
-						propVisitor.Visit(doc, fieldName, field);
+						propVisitor.Visit(newDoc, fieldName, field);
 					}
-					docs.Add(doc);
+					docs.Add(newDoc);
 				}
 			}
 			else

--- a/SolrNet/Properties/AssemblyInfo.cs
+++ b/SolrNet/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("SolrNet")]
 [assembly: AssemblyProduct("SolrNet")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/SolrNet/SolrNet.csproj
+++ b/SolrNet/SolrNet.csproj
@@ -363,6 +363,7 @@
     <Compile Include="StartOrCursor.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="StatsResult.cs" />
+    <Compile Include="Utils\ShallowClone.cs" />
     <Compile Include="Utils\Container.cs" />
     <Compile Include="Exceptions\InvalidURLException.cs" />
     <Compile Include="ISolrConnection.cs" />

--- a/SolrNet/Utils/ShallowClone.cs
+++ b/SolrNet/Utils/ShallowClone.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+
+namespace SolrNet.Utils
+{
+	/// <summary>
+	/// Class for performing a simple/shallow object clone.
+	/// </summary>
+	public static class ShallowClone
+	{
+
+		/// <summary>
+		/// Performs a shallow clone.
+		/// </summary>
+		/// <param name="copyFromObject">Source object</param>
+		/// <typeparam name="T"></typeparam>
+		/// <returns>A copy of the source</returns>
+		public static T Clone<T>(T copyFromObject) {
+			var copyToObject = Activator.CreateInstance<T>();
+
+			foreach (PropertyInfo sourcePropertyInfo in copyFromObject.GetType().GetProperties())
+			{
+				PropertyInfo destPropertyInfo = copyToObject.GetType().GetProperty(sourcePropertyInfo.Name);
+
+				destPropertyInfo.SetValue(
+						copyToObject,
+						sourcePropertyInfo.GetValue(copyFromObject, null),
+						null);
+			}
+
+			return copyToObject;
+		}
+	}
+}

--- a/StructureMap.SolrNetIntegration/Properties/AssemblyInfo.cs
+++ b/StructureMap.SolrNetIntegration/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("StructureMap.SolrNetIntegration")]
 [assembly: AssemblyProduct("StructureMap.SolrNetIntegration")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/Unity.SolrNetIntegration/Properties/AssemblyInfo.cs
+++ b/Unity.SolrNetIntegration/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Unity.SolrNetIntegration")]
 [assembly: AssemblyProduct("Unity.SolrNetIntegration")]
 [assembly: AssemblyCopyright("Copyright Mauricio Scheffer 2007-2016")]
-[assembly: AssemblyVersion("0.5.0.1003")]
-[assembly: AssemblyFileVersion("0.5.0.1003")]
+[assembly: AssemblyVersion("0.5.1.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]
 [assembly: AssemblyInformationalVersion("9c64895feb4a6da57a49849867ddffe69402ed1c")]
 [assembly: AssemblyDelaySign(false)]
 

--- a/build.fsx
+++ b/build.fsx
@@ -10,7 +10,7 @@ open System.Xml.Linq
 open Fake
 open Fake.FileUtils
 
-let version = "0.5.0.1003"
+let version = "0.5.1.0"
 let nugetVersion = "0.5.2"
 let buildDir = "merged"
 let nugetDir = "nuget"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+0.5.1.0 (2017-03-02)
+===
+- Update the `SolrDocumentResponseParser` to also read child documents. Returns flattened documents that represent each child, with properties from its parent. Properties whose names are in both the child and parent will be overridden with the child value.
+
+???
+===
 - Fix handling of NaN in stats
 - Handle multi-value field containing one or more nulls
 


### PR DESCRIPTION
Returns flattened documents that represent each child, with properties from its parent. Properties whose names are in both the child and parent will be overridden with the child value.

Spacing/Line Endings got crazy; tried to fix but wanted to mention:
* Lines 24-25 in committed code are the only changes in `GenericDictionaryDocumentVisitorTests.cs`